### PR TITLE
[CIRCLE-19553, CIRCLE-19323] Debug Node install issues, add more complete Goss tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ master-filters: &master-filters
     only: master
 
 lint-ignore-rules: &lint-ignore-rules
-  DL3006,DL3007,DL3008,DL3015,SC1072,SC1090,SC2039,SC2143 # remove DL3006 later, it's an important one
+  DL3006,DL3007,DL3008,DL3015,SC1072,SC1090,SC2039,SC2143,SC2162,SC2013,SC2062,SC2027,SC2086 # remove DL3006 later, it's an important one
 
 commands:
   prepare-node-dockerfile-from-template:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.11
+  cimg: cci-dev/cimg@0.0.12
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,9 +16,6 @@ master-filters: &master-filters
 lint-ignore-rules: &lint-ignore-rules
   DL3006,DL3007,DL3008,DL3015,SC1072,SC1090,SC2039,SC2143 # remove DL3006 later, it's an important one
 
-node-version-build-args: &node-version-build-args
-  --pull --build-arg NODE_VERSION=$(curl --show-error --location --fail --retry 3 https://api.github.com/repos/nodejs/node/releases | grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
-
 commands:
   prepare-node-dockerfile-from-template:
     parameters:
@@ -89,7 +86,7 @@ workflows:
           dockerfile-path: variant-node
           image-name: cimg/base
           image-tag: "$( date +%Y.%m )-node"
-          extra-build-args: *node-version-build-args
+          extra-build-args: --pull
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true
@@ -143,7 +140,7 @@ workflows:
           dockerfile-path: variant-node
           image-name: ccitest/base
           image-tag: "$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}-node"
-          extra-build-args: *node-version-build-args
+          extra-build-args: --pull
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true
@@ -196,7 +193,7 @@ workflows:
           dockerfile-path: variant-node
           image-name: cimg/base
           image-tag: edge-node
-          extra-build-args: *node-version-build-args
+          extra-build-args: --pull
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,7 +14,7 @@ master-filters: &master-filters
     only: master
 
 lint-ignore-rules: &lint-ignore-rules
-  DL3006,DL3007,DL3008,DL3015,SC1072,SC1090,SC2039,SC2143,SC2162,SC2013,SC2062,SC2027,SC2086 # remove DL3006 later, it's an important one
+  DL3007,DL3008,DL3015,SC1072,SC1090,SC2013,SC2039,SC2143,SC2162,SC2027,SC2062,SC2086
 
 commands:
   prepare-node-dockerfile-from-template:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.18
+  cimg: cci-dev/cimg@0.0.19
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters
@@ -15,6 +15,26 @@ master-filters: &master-filters
 
 lint-ignore-rules: &lint-ignore-rules
   DL3006,DL3007,DL3008,DL3015,SC1072,SC1090,SC2039,SC2143 # remove DL3006 later, it's an important one
+
+commands:
+  prepare-node-dockerfile-from-template:
+    parameters:
+      base-org-image-tag:
+        type: string
+      step-name:
+        type: string
+    steps:
+      - run:
+          name: <<parameters.step-name>>
+          command: |
+            version=<<parameters.base-org-image-tag>>
+
+            sed -r -e 's!%%BASE_ORG_BASE_IMAGE_BASE_TAG%%!'"$version"'!g' \
+              variant-node/Dockerfile.template > variant-node/Dockerfile
+
+      - persist_to_workspace:
+          root: ~/
+          paths: project
 
 workflows:
   monthly-cron:
@@ -43,16 +63,9 @@ workflows:
           filters: *master-filters
           requires: [lint-ubuntu-monthly]
           post-steps:
-            - run:
-                name: Prepare monthly Node variant Dockerfile from template
-                command: |
-                  version="cimg/base:$( date +%Y.%m )"
-
-                  sed -r -e 's!%%BASE_ORG_BASE_IMAGE_BASE_TAG%%!'"$version"'!g' variant-node/Dockerfile.template > variant-node/Dockerfile
-
-            - persist_to_workspace:
-                root: ~/
-                paths: project
+            - prepare-node-dockerfile-from-template:
+                step-name: Prepare monthly Node variant Dockerfile from template
+                base-org-image-tag: "cimg/base:$( date +%Y.%m )"
 
       - docker/hadolint:
           name: lint-node-monthly
@@ -73,7 +86,11 @@ workflows:
           dockerfile-path: variant-node
           image-name: cimg/base
           image-tag: "$( date +%Y.%m )-node"
-          extra-build-args: --pull
+          extra-build-args: |
+            --pull --build-arg NODE_VERSION=$(curl \
+              --show-error --location --fail --retry 3 \
+              https://api.github.com/repos/nodejs/node/releases | \
+              grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true
@@ -103,16 +120,9 @@ workflows:
           filters: *dev-filters
           requires: [lint-ubuntu-edge-dev]
           post-steps:
-            - run:
-                name: Prepare ccitest/base Node variant Dockerfile from template
-                command: |
-                  version="ccitest/base:$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}"
-
-                  sed -r -e 's!%%BASE_ORG_BASE_IMAGE_BASE_TAG%%!'"$version"'!g' variant-node/Dockerfile.template > variant-node/Dockerfile
-
-            - persist_to_workspace:
-                root: ~/
-                paths: project
+            - prepare-node-dockerfile-from-template:
+                step-name: Prepare ccitest/base Node variant Dockerfile from template
+                base-org-image-tag: "ccitest/base:$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}"
 
       - docker/hadolint:
           name: lint-node-edge-dev
@@ -134,7 +144,11 @@ workflows:
           dockerfile-path: variant-node
           image-name: ccitest/base
           image-tag: "$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}-node"
-          extra-build-args: --pull
+          extra-build-args: |
+            --pull --build-arg NODE_VERSION=$(curl \
+              --show-error --location --fail --retry 3 \
+              https://api.github.com/repos/nodejs/node/releases | \
+              grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true
@@ -163,16 +177,9 @@ workflows:
           filters: *master-filters
           requires: [lint-ubuntu-edge-master]
           post-steps:
-            - run:
-                name: Prepare edge Node variant Dockerfile from template
-                command: |
-                  version=cimg/base:edge
-
-                  sed -r -e 's!%%BASE_ORG_BASE_IMAGE_BASE_TAG%%!'"$version"'!g' variant-node/Dockerfile.template > variant-node/Dockerfile
-
-            - persist_to_workspace:
-                root: ~/
-                paths: project
+            - prepare-node-dockerfile-from-template:
+                step-name: Prepare edge Node variant Dockerfile from template
+                base-org-image-tag: cimg/base:edge
 
       - docker/hadolint:
           name: lint-node-edge-master
@@ -194,7 +201,11 @@ workflows:
           dockerfile-path: variant-node
           image-name: cimg/base
           image-tag: edge-node
-          extra-build-args: --pull
+          extra-build-args: |
+            --pull --build-arg NODE_VERSION=$(curl \
+              --show-error --location --fail --retry 3 \
+              https://api.github.com/repos/nodejs/node/releases | \
+              grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.16
+  cimg: cci-dev/cimg@0.0.17
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.14
+  cimg: cci-dev/cimg@0.0.15
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -97,6 +97,7 @@ workflows:
           image-tag: "$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}"
           extra-build-args: --pull
           goss-yaml-dir-path: ubuntu
+          test-suite-name: ubuntu
           deploy: true
           publish-tags: latest
           filters: *dev-filters
@@ -135,6 +136,7 @@ workflows:
           image-tag: "$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}-node"
           extra-build-args: --pull
           goss-yaml-dir-path: variant-node
+          test-suite-name: variant-node
           deploy: true
           filters: *dev-filters
           requires: [lint-node-edge-dev]
@@ -155,6 +157,7 @@ workflows:
           image-tag: edge
           extra-build-args: --pull
           goss-yaml-dir-path: ubuntu
+          test-suite-name: ubuntu
           deploy: true
           publish-tags: latest
           filters: *master-filters
@@ -193,6 +196,7 @@ workflows:
           image-tag: edge-node
           extra-build-args: --pull
           goss-yaml-dir-path: variant-node
+          test-suite-name: variant-node
           deploy: true
           filters: *master-filters
           requires: [lint-node-edge-master]

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.12
+  cimg: cci-dev/cimg@0.0.13
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.15
+  cimg: cci-dev/cimg@0.0.16
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.13
+  cimg: cci-dev/cimg@0.0.14
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters
@@ -37,6 +37,7 @@ workflows:
           image-tag: "$( date +%Y.%m )"
           extra-build-args: --pull
           goss-yaml-dir-path: ubuntu
+          test-suite-name: ubuntu
           deploy: true
           publish-tags: stable,latest
           filters: *master-filters
@@ -74,6 +75,7 @@ workflows:
           image-tag: "$( date +%Y.%m )-node"
           extra-build-args: --pull
           goss-yaml-dir-path: variant-node
+          test-suite-name: variant-node
           deploy: true
           publish-tags: stable-node
           filters: *master-filters

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,9 @@ master-filters: &master-filters
 lint-ignore-rules: &lint-ignore-rules
   DL3006,DL3007,DL3008,DL3015,SC1072,SC1090,SC2039,SC2143 # remove DL3006 later, it's an important one
 
+node-version-build-args: &node-version-build-args
+  --pull --build-arg NODE_VERSION=$(curl --show-error --location --fail --retry 3 https://api.github.com/repos/nodejs/node/releases | grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
+
 commands:
   prepare-node-dockerfile-from-template:
     parameters:
@@ -86,11 +89,7 @@ workflows:
           dockerfile-path: variant-node
           image-name: cimg/base
           image-tag: "$( date +%Y.%m )-node"
-          extra-build-args: |
-            --pull --build-arg NODE_VERSION=$(curl \
-              --show-error --location --fail --retry 3 \
-              https://api.github.com/repos/nodejs/node/releases | \
-              grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
+          extra-build-args: *node-version-build-args
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true
@@ -144,11 +143,7 @@ workflows:
           dockerfile-path: variant-node
           image-name: ccitest/base
           image-tag: "$CIRCLE_BRANCH-${CIRCLE_SHA1:0:7}-node"
-          extra-build-args: |
-            --pull --build-arg NODE_VERSION=$(curl \
-              --show-error --location --fail --retry 3 \
-              https://api.github.com/repos/nodejs/node/releases | \
-              grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
+          extra-build-args: *node-version-build-args
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true
@@ -201,11 +196,7 @@ workflows:
           dockerfile-path: variant-node
           image-name: cimg/base
           image-tag: edge-node
-          extra-build-args: |
-            --pull --build-arg NODE_VERSION=$(curl \
-              --show-error --location --fail --retry 3 \
-              https://api.github.com/repos/nodejs/node/releases | \
-              grep "(LTS)" | head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ")
+          extra-build-args: *node-version-build-args
           goss-yaml-dir-path: variant-node
           test-suite-name: variant-node
           deploy: true

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,7 +2,7 @@ version: 2.1
 
 orbs:
   bt: circleci/build-tools@2.6.3
-  cimg: cci-dev/cimg@0.0.17
+  cimg: cci-dev/cimg@0.0.18
   docker: circleci/docker@0.5.10
 
 dev-filters: &dev-filters

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ FROM cimg/base:stable
 
 You can also use this image directly in CircleCI if you need a light-weight image to run generic commands or orb-based commands.
 
+## Variants
+
+Currently, there is only a Node variant of this image. The Node variant includes the latest LTS version of Node. To install a different version, use [CircleCI's Node orb](http://circleci.com/orbs/registry/orb/circleci/node#commands-install-node). See below for explanation of specific `-node` (and other) tags.
 
 ## Tags
 

--- a/ubuntu/goss.yaml
+++ b/ubuntu/goss.yaml
@@ -1,6 +1,10 @@
 file:
   /bin/bash:
     exists: true
+  /usr/bin/docker-compose:
+    exists: true
+  /usr/bin/dockerize:
+    exists: true
 
 command:
   bash:
@@ -8,10 +12,6 @@ command:
   circleci:
     exit-status: 0
   docker:
-    exit-status: 0
-  docker-compose:
-    exit-status: 0
-  dockerize:
     exit-status: 0
 
 package:

--- a/ubuntu/goss.yaml
+++ b/ubuntu/goss.yaml
@@ -1,7 +1,3 @@
-file:
-  /bin/bash:
-    exists: true
-
 command:
   bash:
     exit-status: 0
@@ -9,12 +5,10 @@ command:
     exit-status: 0
   docker:
     exit-status: 0
-  docker-compose:
+  docker-compose --version:
     exit-status: 0
-    exec: "docker-compose --version"
-  dockerize:
+  dockerize --version:
     exit-status: 0
-    exec: "dockerize --version"
 
 package:
   build-essential:

--- a/ubuntu/goss.yaml
+++ b/ubuntu/goss.yaml
@@ -1,10 +1,6 @@
 file:
   /bin/bash:
     exists: true
-  /usr/bin/docker-compose:
-    exists: true
-  /usr/bin/dockerize:
-    exists: true
 
 command:
   bash:
@@ -13,6 +9,12 @@ command:
     exit-status: 0
   docker:
     exit-status: 0
+  docker-compose:
+    exit-status: 0
+    exec: "docker-compose --version"
+  dockerize:
+    exit-status: 0
+    exec: "dockerize --version"
 
 package:
   build-essential:

--- a/ubuntu/goss.yaml
+++ b/ubuntu/goss.yaml
@@ -1,4 +1,61 @@
 file:
-  # ensure a Bash shell exists
   /bin/bash:
+    exists: true
+
+command:
+  bash:
+    exit-status: 0
+  circleci:
+    exit-status: 0
+  docker:
+    exit-status: 0
+  docker-compose:
+    exit-status: 0
+  dockerize:
+    exit-status: 0
+
+package:
+  build-essential:
+    installed: true
+  bzip2:
+    installed: true
+  ca-certificates:
+    installed: true
+  curl:
+    installed: true
+  git:
+    installed: true
+  gnupg:
+    installed: true
+  gzip:
+    installed: true
+  jq:
+    installed: true
+  locales:
+    installed: true
+  make:
+    installed: true
+  mercurial:
+    installed: true
+  net-tools:
+    installed: true
+  netcat:
+    installed: true
+  openssh-client:
+    installed: true
+  parallel:
+    installed: true
+  tar:
+    installed: true
+  unzip:
+    installed: true
+  wget:
+    installed: true
+  xvfb:
+    installed: true
+  zip:
+    installed: true
+
+user:
+  root:
     exists: true

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -13,32 +13,60 @@ LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partn
 # Set default shell for building image
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
-ARG NODE_VERSION
-ENV NODE_VERSION="$NODE_VERSION"
-
-# Install NVM
-RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
-  https://api.github.com/repos/nvm-sh/nvm/releases/latest | \
-  jq '.tag_name' | sed -E 's/"//g') \
-  # extract latest version from GitHub releases API
-  && curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash \
-	&& source ~/.nvm/nvm.sh \
-	&& echo "source ~/.nvm/nvm.sh" >> ~/.bashrc \
-	&& command -v nvm \
-	&& nvm --version | grep "${NVM_VERSION:1}" \
-	&& nvm install "$NODE_VERSION" \
-	# set Node LTS release as default
-	&& nvm use "$NODE_VERSION"
-
-# Add Node, NPM, NVM to path so the commands are available
-ENV NVM_DIR $HOME/.nvm
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-# Set symmlinks
-RUN ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/node" /usr/bin/nodejs \
-	&& ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/node" /usr/bin/node \
-	&& ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/npm" /usr/bin/npm
+# Install Node
+RUN NODE_VERSION=$(curl --show-error --location --fail --retry 3 \
+	https://api.github.com/repos/nodejs/node/releases | grep "(LTS)" | \
+	head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ") \
+	# grab Node.js release keys
+	&& curl --show-error --location --fail --retry 3 \
+    https://raw.githubusercontent.com/nodejs/node/master/README.md | \
+    grep -E '[A-Z0-9]{40}' | \
+    sed -E 's/gpg --keyserver pool.sks-keyservers.net --recv-keys //g' | \
+    sed -E 's/(`|\$ )//g' > NODEJS_TRUSTED_RELEASE_KEYS \
+  # set keyservers to use
+  && echo "hkp://p80.pool.sks-keyservers.net:80" >> KEYSERVERS \
+  && echo "hkp://ipv4.pool.sks-keyservers.net" >> KEYSERVERS \
+	&& echo "hkp://pgp.mit.edu:80" >> KEYSERVERS \
+	&& echo "hkps://ha.pool.sks-keyservers.net" >> KEYSERVERS \
+	&& echo "hkp://keyserver.ubuntu.com:80" >> KEYSERVERS \
+	# import release keys
+	&& while read key; do \
+    for keyserver in $(cat KEYSERVERS); do \
+      tempName=$(mktemp) && \
+      gpg --status-fd 1 \
+        --keyserver "$keyserver" --keyserver-options "timeout=1" \
+        --recv-keys "$key" 1> "$tempName" || true && \
+      if [[ $(grep "^\[GNUPG\:\] IMPORT_OK "[[:digit:]]*" "$key"$" $tempName && \
+        grep "^\[GNUPG\:\] IMPORT_RES 1" $tempName) ]]; then \
+        echo "Success! Imported $key from $keyserver" && \
+        break \
+      else \
+        continue \
+      fi \
+    done \
+  done < NODEJS_TRUSTED_RELEASE_KEYS \
+  && rm -f NODEJS_TRUSTED_RELEASE_KEYS KEYSERVERS \
+  # download encrypted shasums file
+  && curl -O --show-error --location --fail --retry 3 \
+    "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+  # decrypt shasums file
+  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc && rm -f SHASUMS256.txt.asc \
+  # download/install node
+  && curl -O --show-error --location --fail --retry 3 \
+    "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+  # verify node tar via shasum256
+  && grep "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt | sha256sum -c - && rm -f SHASUMS256.txt \
+  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local \
+    --strip-components=1 --no-same-owner \
+  && rm -f "node-v$NODE_VERSION-linux-x64.tar.gz" \
+  && if [[ ! -e /usr/local/bin/nodejs ]]; then \
+    ln -s /usr/local/bin/node /usr/local/bin/nodejs \
+  fi \
+  # test/verify version
+  && command -v node \
+  && command -v npm \
+  && node --version | grep "$NODE_VERSION" \
+  && npm --version
 
 # Set default shell for users
 SHELL ["/bin/bash", "-c"]

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -39,10 +39,10 @@ RUN NODE_VERSION=$(curl --show-error --location --fail --retry 3 \
       if [[ $(grep "^\[GNUPG\:\] IMPORT_OK "[[:digit:]]*" "$key"$" $tempName && \
         grep "^\[GNUPG\:\] IMPORT_RES 1" $tempName) ]]; then \
         echo "Success! Imported $key from $keyserver" && \
-        break \
+        break; \
       else \
-        continue \
-      fi \
+        continue; \
+      fi; \
     done \
   done < NODEJS_TRUSTED_RELEASE_KEYS \
   && rm -f NODEJS_TRUSTED_RELEASE_KEYS KEYSERVERS \
@@ -61,7 +61,7 @@ RUN NODE_VERSION=$(curl --show-error --location --fail --retry 3 \
   && rm -f "node-v$NODE_VERSION-linux-x64.tar.gz" \
   && if [[ ! -e /usr/local/bin/nodejs ]]; then \
     ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-  fi \
+  fi; \
   # test/verify version
   && command -v node \
   && command -v npm \

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -19,54 +19,54 @@ RUN NODE_VERSION=$(curl --show-error --location --fail --retry 3 \
 	head -n 1 | sed -E 's|.*Version ||' | cut -f1 -d" ") \
 	# grab Node.js release keys
 	&& curl --show-error --location --fail --retry 3 \
-    https://raw.githubusercontent.com/nodejs/node/master/README.md | \
-    grep -E '[A-Z0-9]{40}' | \
-    sed -E 's/gpg --keyserver pool.sks-keyservers.net --recv-keys //g' | \
-    sed -E 's/(`|\$ )//g' > NODEJS_TRUSTED_RELEASE_KEYS \
-  # set keyservers to use
-  && echo "hkp://p80.pool.sks-keyservers.net:80" >> KEYSERVERS \
-  && echo "hkp://ipv4.pool.sks-keyservers.net" >> KEYSERVERS \
+		https://raw.githubusercontent.com/nodejs/node/master/README.md | \
+		grep -E '[A-Z0-9]{40}' | \
+		sed -E 's/gpg --keyserver pool.sks-keyservers.net --recv-keys //g' | \
+		sed -E 's/(`|\$ )//g' > NODEJS_TRUSTED_RELEASE_KEYS \
+	# set keyservers to use
+	&& echo "hkp://p80.pool.sks-keyservers.net:80" >> KEYSERVERS \
+	&& echo "hkp://ipv4.pool.sks-keyservers.net" >> KEYSERVERS \
 	&& echo "hkp://pgp.mit.edu:80" >> KEYSERVERS \
 	&& echo "hkps://ha.pool.sks-keyservers.net" >> KEYSERVERS \
 	&& echo "hkp://keyserver.ubuntu.com:80" >> KEYSERVERS \
 	# import release keys
-	&& while read key; do \
-    for keyserver in $(cat KEYSERVERS); do \
-      tempName=$(mktemp) && \
-      gpg --status-fd 1 \
-        --keyserver "$keyserver" --keyserver-options "timeout=1" \
-        --recv-keys "$key" 1> "$tempName" || true && \
-      if [[ $(grep "^\[GNUPG\:\] IMPORT_OK "[[:digit:]]*" "$key"$" $tempName && \
-        grep "^\[GNUPG\:\] IMPORT_RES 1" $tempName) ]]; then \
-        echo "Success! Imported $key from $keyserver" && \
-        break; \
-      else \
-        continue; \
-      fi; \
-    done \
-  done < NODEJS_TRUSTED_RELEASE_KEYS \
-  && rm -f NODEJS_TRUSTED_RELEASE_KEYS KEYSERVERS \
-  # download encrypted shasums file
-  && curl -O --show-error --location --fail --retry 3 \
-    "https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
-  # decrypt shasums file
-  && gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc && rm -f SHASUMS256.txt.asc \
-  # download/install node
-  && curl -O --show-error --location --fail --retry 3 \
-    "https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
-  # verify node tar via shasum256
-  && grep "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt | sha256sum -c - && rm -f SHASUMS256.txt \
-  && tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local \
-    --strip-components=1 --no-same-owner \
-  && rm -f "node-v$NODE_VERSION-linux-x64.tar.gz" \
-  && if [[ ! -e /usr/local/bin/nodejs ]]; then \
-    ln -s /usr/local/bin/node /usr/local/bin/nodejs \
-  fi; \
-  # test/verify version
-  && command -v node \
-  && command -v npm \
-  && node --version | grep "$NODE_VERSION" \
-  && npm --version
+	&& while read key; \
+		do for keyserver in $(cat KEYSERVERS); \
+			do tempName=$(mktemp) \
+			&& gpg --status-fd 1 \
+				--keyserver "$keyserver" --keyserver-options "timeout=1" \
+				--recv-keys "$key" 1> "$tempName" || true \
+			&& if [[ $(grep "^\[GNUPG\:\] IMPORT_OK "[[:digit:]]*" "$key"$" $tempName \
+				&& grep "^\[GNUPG\:\] IMPORT_RES 1" "$tempName") ]]; then \
+				echo "Success! Imported $key from $keyserver" && \
+				break; \
+			else \
+				continue; \
+			fi; \
+		done \
+	done < NODEJS_TRUSTED_RELEASE_KEYS \
+	&& rm -f NODEJS_TRUSTED_RELEASE_KEYS KEYSERVERS \
+	# download encrypted shasums file
+	&& curl -O --show-error --location --fail --retry 3 \
+		"https://nodejs.org/dist/v$NODE_VERSION/SHASUMS256.txt.asc" \
+	# decrypt shasums file
+	&& gpg --batch --decrypt --output SHASUMS256.txt SHASUMS256.txt.asc && rm -f SHASUMS256.txt.asc \
+	# download/install node
+	&& curl -O --show-error --location --fail --retry 3 \
+		"https://nodejs.org/dist/v$NODE_VERSION/node-v$NODE_VERSION-linux-x64.tar.gz" \
+	# verify node tar via shasum256
+	&& grep "node-v$NODE_VERSION-linux-x64.tar.gz" SHASUMS256.txt | sha256sum -c - && rm -f SHASUMS256.txt \
+	&& tar -xzf "node-v$NODE_VERSION-linux-x64.tar.gz" -C /usr/local \
+		--strip-components=1 --no-same-owner \
+	&& rm -f "node-v$NODE_VERSION-linux-x64.tar.gz" \
+	&& if [[ ! -e /usr/local/bin/nodejs ]]; then \
+		ln -s /usr/local/bin/node /usr/local/bin/nodejs; \
+	fi \
+	# test/verify version
+	&& command -v node \
+	&& command -v npm \
+	&& node --version | grep "$NODE_VERSION" \
+	&& npm --version
 
 # Set default shell for users
 SHELL ["/bin/bash", "-c"]

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -20,6 +20,7 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
   # extract latest version from GitHub releases API
   && curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash \
 	&& source ~/.nvm/nvm.sh \
+	&& echo "source ~/.nvm/nvm.sh" >> ~/.bashrc \
 	&& command -v nvm \
 	&& nvm --version | grep "${NVM_VERSION:1}" \
 	&& nvm install --lts \

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -20,6 +20,7 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
   # extract latest version from GitHub releases API
   && curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash \
 	&& source ~/.nvm/nvm.sh \
+	&& command -v nvm \
 	&& nvm --version | grep "${NVM_VERSION:1}" \
 	&& nvm install --lts \
 	# set Node LTS release as default

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -31,9 +31,9 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
 	&& nvm use "$NODE_VERSION"
 
 # Add Node, NPM, NVM to path so the commands are available
-ENV NVM_DIR "$HOME/.nvm"
-ENV NODE_PATH "$NVM_DIR/v$NODE_VERSION/lib/node_modules"
-ENV PATH "$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
+ENV NVM_DIR $HOME/.nvm
+ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
+ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # Set symmlinks
 RUN ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/node" /usr/bin/nodejs \

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -24,15 +24,16 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
   jq '.tag_name' | sed -E 's/"//g') \
   # extract latest version from GitHub releases API
   && curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash \
-	&& source "$NVM_DIR/nvm.sh" \
-	&& echo "source $NVM_DIR/nvm.sh" >> ~/.bashrc \
+	&& source ~/.nvm/nvm.sh \
+	&& echo "source ~/.nvm/nvm.sh" >> ~/.bashrc \
 	&& command -v nvm \
 	&& nvm --version | grep "${NVM_VERSION:1}" \
 	&& nvm install "$NODE_VERSION" \
 	# set Node LTS release as default
 	&& nvm use "$NODE_VERSION"
 
-# Add Node, NPM to path so the commands are available
+# Add Node, NPM, NVM to path so the commands are available
+ENV NVM_DIR $HOME/.nvm
 ENV NODE_PATH "$NVM_DIR/v$NODE_VERSION/lib/node_modules"
 ENV PATH "$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
 

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -13,7 +13,7 @@ LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partn
 # Set default shell for building image
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
-ENV NVM_DIR /usr/local/nvm
+ENV NVM_DIR "$HOME/.nvm"
 
 ARG NODE_VERSION
 ENV NODE_VERSION="$NODE_VERSION"
@@ -28,9 +28,9 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
 	&& echo "source $NVM_DIR/nvm.sh" >> ~/.bashrc \
 	&& command -v nvm \
 	&& nvm --version | grep "${NVM_VERSION:1}" \
-	&& nvm install "NODE_VERSION" \
+	&& nvm install "$NODE_VERSION" \
 	# set Node LTS release as default
-	&& nvm use "NODE_VERSION"
+	&& nvm use "$NODE_VERSION"
 
 # Add Node, NPM to path so the commands are available
 ENV NODE_PATH "$NVM_DIR/v$NODE_VERSION/lib/node_modules"

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -21,13 +21,20 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
   && curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash \
 	&& source ~/.nvm/nvm.sh \
 	&& nvm --version | grep "${NVM_VERSION:1}" \
-	&& nvm install --lts
+	&& nvm install --lts \
+	# set Node LTS release as default
+	&& nvm alias default --lts \
+	&& nvm use default
 
-ENV NVM_DIR $HOME/.nvm
+# Add Node, NPM, NVM to path so the commands are available
+ENV NVM_DIR "$HOME/.nvm"
+ENV NODE_PATH "$NVM_DIR/v$NODE_VERSION/lib/node_modules"
+ENV PATH "$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
 
-# Add node and npm to path so the commands are available
-ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
-ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+# Set symmlinks
+RUN ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/node" /usr/bin/nodejs \
+	&& ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/node" /usr/bin/node \
+	&& ln -sf "$NVM_DIR/versions/node/v$NODE_VERSION/bin/npm" /usr/bin/npm
 
 # Set default shell for users
 SHELL ["/bin/bash", "-c"]

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -13,8 +13,6 @@ LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partn
 # Set default shell for building image
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
-ENV NVM_DIR "$HOME/.nvm"
-
 ARG NODE_VERSION
 ENV NODE_VERSION="$NODE_VERSION"
 
@@ -33,7 +31,7 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
 	&& nvm use "$NODE_VERSION"
 
 # Add Node, NPM, NVM to path so the commands are available
-ENV NVM_DIR $HOME/.nvm
+ENV NVM_DIR "$HOME/.nvm"
 ENV NODE_PATH "$NVM_DIR/v$NODE_VERSION/lib/node_modules"
 ENV PATH "$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
 

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -13,22 +13,26 @@ LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partn
 # Set default shell for building image
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
+ENV NVM_DIR /usr/local/nvm
+
+ARG NODE_VERSION
+ENV NODE_VERSION="$NODE_VERSION"
+
 # Install NVM
 RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
   https://api.github.com/repos/nvm-sh/nvm/releases/latest | \
   jq '.tag_name' | sed -E 's/"//g') \
   # extract latest version from GitHub releases API
   && curl -o- "https://raw.githubusercontent.com/nvm-sh/nvm/$NVM_VERSION/install.sh" | bash \
-	&& source ~/.nvm/nvm.sh \
-	&& echo "source ~/.nvm/nvm.sh" >> ~/.bashrc \
+	&& source "$NVM_DIR/nvm.sh" \
+	&& echo "source $NVM_DIR/nvm.sh" >> ~/.bashrc \
 	&& command -v nvm \
 	&& nvm --version | grep "${NVM_VERSION:1}" \
-	&& nvm install --lts \
+	&& nvm install "NODE_VERSION" \
 	# set Node LTS release as default
-	&& nvm use --lts
+	&& nvm use "NODE_VERSION"
 
-# Add Node, NPM, NVM to path so the commands are available
-ENV NVM_DIR "$HOME/.nvm"
+# Add Node, NPM to path so the commands are available
 ENV NODE_PATH "$NVM_DIR/v$NODE_VERSION/lib/node_modules"
 ENV PATH "$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH"
 

--- a/variant-node/Dockerfile.template
+++ b/variant-node/Dockerfile.template
@@ -23,8 +23,7 @@ RUN NVM_VERSION=$(curl --show-error --location --fail --retry 3 \
 	&& nvm --version | grep "${NVM_VERSION:1}" \
 	&& nvm install --lts \
 	# set Node LTS release as default
-	&& nvm alias default --lts \
-	&& nvm use default
+	&& nvm use --lts
 
 # Add Node, NPM, NVM to path so the commands are available
 ENV NVM_DIR "$HOME/.nvm"

--- a/variant-node/goss.yaml
+++ b/variant-node/goss.yaml
@@ -1,10 +1,6 @@
 file:
   /bin/bash:
     exists: true
-  /usr/bin/docker-compose:
-    exists: true
-  /usr/bin/dockerize:
-    exists: true
 
 command:
   bash:
@@ -13,10 +9,21 @@ command:
     exit-status: 0
   docker:
     exit-status: 0
+  docker-compose:
+    exit-status: 0
+    exec: "docker-compose --version"
+  dockerize:
+    exit-status: 0
+    exec: "dockerize --version"
   node:
     exit-status: 0
+    exec: "node --version"
+  npm:
+    exit-status: 0
+    exec: "npm install test-npm-install"
   nvm:
     exit-status: 0
+    exec: "nvm use --lts"
 
 package:
   build-essential:

--- a/variant-node/goss.yaml
+++ b/variant-node/goss.yaml
@@ -11,13 +11,10 @@ command:
     exit-status: 0
   node --version:
     exit-status: 0
-    timeout: 10000
   npm --version:
     exit-status: 0
-    timeout: 10000
   nvm --version:
     exit-status: 0
-    timeout: 10000
 
 package:
   build-essential:

--- a/variant-node/goss.yaml
+++ b/variant-node/goss.yaml
@@ -1,4 +1,65 @@
 file:
-  # ensure a Bash shell exists
   /bin/bash:
+    exists: true
+
+command:
+  bash:
+    exit-status: 0
+  circleci:
+    exit-status: 0
+  docker:
+    exit-status: 0
+  docker-compose:
+    exit-status: 0
+  dockerize:
+    exit-status: 0
+  node:
+    exit-status: 0
+  nvm:
+    exit-status: 0
+
+package:
+  build-essential:
+    installed: true
+  bzip2:
+    installed: true
+  ca-certificates:
+    installed: true
+  curl:
+    installed: true
+  git:
+    installed: true
+  gnupg:
+    installed: true
+  gzip:
+    installed: true
+  jq:
+    installed: true
+  locales:
+    installed: true
+  make:
+    installed: true
+  mercurial:
+    installed: true
+  net-tools:
+    installed: true
+  netcat:
+    installed: true
+  openssh-client:
+    installed: true
+  parallel:
+    installed: true
+  tar:
+    installed: true
+  unzip:
+    installed: true
+  wget:
+    installed: true
+  xvfb:
+    installed: true
+  zip:
+    installed: true
+
+user:
+  root:
     exists: true

--- a/variant-node/goss.yaml
+++ b/variant-node/goss.yaml
@@ -1,6 +1,10 @@
 file:
   /bin/bash:
     exists: true
+  /usr/bin/docker-compose:
+    exists: true
+  /usr/bin/dockerize:
+    exists: true
 
 command:
   bash:
@@ -8,10 +12,6 @@ command:
   circleci:
     exit-status: 0
   docker:
-    exit-status: 0
-  docker-compose:
-    exit-status: 0
-  dockerize:
     exit-status: 0
   node:
     exit-status: 0

--- a/variant-node/goss.yaml
+++ b/variant-node/goss.yaml
@@ -1,7 +1,3 @@
-file:
-  /bin/bash:
-    exists: true
-
 command:
   bash:
     exit-status: 0
@@ -9,21 +5,16 @@ command:
     exit-status: 0
   docker:
     exit-status: 0
-  docker-compose:
+  docker-compose --version:
     exit-status: 0
-    exec: "docker-compose --version"
-  dockerize:
+  dockerize --version:
     exit-status: 0
-    exec: "dockerize --version"
-  node:
+  node --version:
     exit-status: 0
-    exec: "node --version"
-  npm:
+  npm --version:
     exit-status: 0
-    exec: "npm install test-npm-install"
-  nvm:
+  nvm --version:
     exit-status: 0
-    exec: "nvm use --lts"
 
 package:
   build-essential:

--- a/variant-node/goss.yaml
+++ b/variant-node/goss.yaml
@@ -13,8 +13,6 @@ command:
     exit-status: 0
   npm --version:
     exit-status: 0
-  nvm --version:
-    exit-status: 0
 
 package:
   build-essential:

--- a/variant-node/goss.yaml
+++ b/variant-node/goss.yaml
@@ -11,10 +11,13 @@ command:
     exit-status: 0
   node --version:
     exit-status: 0
+    timeout: 10000
   npm --version:
     exit-status: 0
+    timeout: 10000
   nvm --version:
     exit-status: 0
+    timeout: 10000
 
 package:
   build-essential:


### PR DESCRIPTION
### Add full suite of Goss tests
The tests are currently very simple—just running basic commands and checking exit status—but can be expanded later

### Switch from `nvm` to regular Node install
I was unable to get basic Goss tests to pass with the `nvm` installation of Node—the `nvm`, `node`, and `npm` commands consistently returned `127` error codes, and I was unable to debug them despite much effort. Instead, we juste install the latest LTS version of Node.js, using logic borrowed from the [Node orb](http://circleci.com/orbs/registry/orb/circleci/node#commands-install-node). If customers want a different version, they can run that same orb command at runtime without much trouble.