### PR TITLE
fixes #22, uses explicit HOME path

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -10,6 +10,7 @@ LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partn
 SHELL ["/usr/bin/env", "bash", "-exo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND	noninteractive
+ENV HOME			/root
 ENV PATH			$HOME/bin:$HOME/.local/bin:$PATH
 
 RUN apt-get update && apt-get install -y \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -10,6 +10,7 @@ LABEL maintainer="CircleCI Community & Partner Engineering Team <community-partn
 SHELL ["/usr/bin/env", "bash", "-exo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND	noninteractive
+ENV HOME			/root
 ENV PATH			$HOME/bin:$HOME/.local/bin:$PATH
 
 RUN apt-get update && apt-get install -y \


### PR DESCRIPTION
FIxes #22 

This PR sets explicit HOME within dockerfile so that subsequent ENV PATH commands suceed.

The result is path as intended

```
$ docker run -it test/base:18.04 bash
root@ba395af237db:~/project# echo $PATH
/root/bin:/root/.local/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```