### PR TITLE
add transparent SUDO command

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -73,6 +73,10 @@ RUN curl -sSL --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz "https
 	# Quick test of Dockerize
 	dockerize --version
 
+# Add sudo command alias 
+RUN echo 'alias sudo=""' >> /root/.bashrc
+RUN echo 'alias SUDO=""' >> /root/.bashrc
+
 # Set default shell for users
 SHELL ["/bin/bash", "-c"]
 


### PR DESCRIPTION
users migrating from legacy types or machine/macos likely have multiple SUDO prefixing their commands, possibly in reusable commands/jobs used across executors.  Removing these would be an adoption hurdle, but worse, might break matrixed/reusables jobs.

This change adds a SUDO/sudo alias that does nothing. This allows our root user to happily execute sudo prefixed commands.


Before
``` bash
root@1961c6f27f82:~/project# SUDO whomai
bash: SUDO: command not found
```

After
``` bash
root@1961c6f27f82:~/project# SUDO whoami
root
```