### PR TITLE
Fix missing context for monthly release.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,7 +11,8 @@ workflows:
             branches:
               only: master
     jobs:
-      - test
+      - test:
+          context: orb-publishing
       - publish-monthly:
           requires:
             - test


### PR DESCRIPTION
When Stubb was added, we need Docker creds for the test job now. It's missing.