### PR TITLE
Fix project dir owner

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -75,6 +75,7 @@ RUN useradd --uid=3434 --user-group --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
 	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
 USER circleci
+RUN mkdir -p /home/circleci/project
 
 # Match the default CircleCI working directory
 WORKDIR /home/circleci/project

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -75,6 +75,7 @@ RUN useradd --uid=3434 --user-group --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
 	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep
 USER circleci
+RUN mkdir -p /home/circleci/project
 
 # Match the default CircleCI working directory
 WORKDIR /home/circleci/project


### PR DESCRIPTION
Fixes #40 

USER does not affect WORKDIR command, so project dir must be created
separately in a RUN step. Otherwise the owner would be root.