### PR TITLE
Add popular editors for SSH-enabled builds.

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && apt-get install -y \
 		# popular DB lib - PostgreSQL
 		libpq-dev \
 		make \
+		# for ssh-enabled builds
+		nano \
 		net-tools \
 		netcat \
 		openssh-client \
@@ -46,6 +48,8 @@ RUN apt-get update && apt-get install -y \
 		tar \
 		tzdata \
 		unzip \
+		# for ssh-enabled builds
+		vim \
 		wget \
 		zip && \
 	rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -37,6 +37,8 @@ RUN apt-get update && apt-get install -y \
 		# popular DB lib - PostgreSQL
 		libpq-dev \
 		make \
+		# for ssh-enabled builds
+		nano \
 		net-tools \
 		netcat \
 		openssh-client \
@@ -46,6 +48,8 @@ RUN apt-get update && apt-get install -y \
 		tar \
 		tzdata \
 		unzip \
+		# for ssh-enabled builds
+		vim \
 		wget \
 		zip && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
This adds the two most popular terminal text editors. This enables a better experience when users use CircleCI's "rebuild with SSH" option. Right now if they do that and want to look at/edit any file, then have to first update the apt cache and then install one of these.