### PR TITLE
Add Ubuntu 20.04 'Focal' support.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,12 +88,16 @@ jobs:
           command: |
             ./build-images.sh
             docker tag cimg/base:18.04 cimg/base:edge
+            docker tag cimg/base:18.04 cimg/base:edge-18.04
+            docker tag cimg/base:20.04 cimg/base:edge-20.04
       - deploy:
           name: "Publish Docker Images (master branch only)"
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
               docker push cimg/base:edge
+              docker push cimg/base:edge-18.04
+              docker push cimg/base:edge-20.04
             fi
 
   publish-monthly:
@@ -107,19 +111,31 @@ jobs:
           command: |
             ./build-images.sh
             docker tag cimg/base:18.04 cimg/base:stable
+            docker tag cimg/base:18.04 cimg/base:stable-18.04
+            docker tag cimg/base:18.04 cimg/base:stable-20.04
             VERSION=$( date +%Y.%m )
             docker tag cimg/base:18.04 cimg/base:${VERSION}
+            docker tag cimg/base:18.04 cimg/base:${VERSION}-18.04
+            docker tag cimg/base:18.04 cimg/base:${VERSION}-20.04
       - deploy:
           name: "Publish Docker Images (master branch only)"
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then
               echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
               docker push cimg/base:stable
+              docker push cimg/base:stable-18.04
+              docker push cimg/base:stable-20.04
               VERSION=$( date +%Y.%m )
               docker push cimg/base:${VERSION}
+              docker push cimg/base:${VERSION}-18.04
+              docker push cimg/base:${VERSION}-20.04
             elif [ "${CIRCLE_TAG}" == "monthly" ]; then
               echo $DOCKER_PASS | docker login -u $DOCKER_USER --password-stdin
               docker push cimg/base:stable
+              docker push cimg/base:stable-18.04
+              docker push cimg/base:stable-20.04
               VERSION=$( date +%Y.%m )
               docker push cimg/base:${VERSION}
+              docker push cimg/base:${VERSION}-18.04
+              docker push cimg/base:${VERSION}-20.04
             fi

--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 		software-properties-common && \
 	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
 	add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
-	apt-get install -y docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} containerd.io && \
+	apt-get install -y docker-ce=${DOCKER_VERSION}$(lsb_release -cs) docker-ce-cli=${DOCKER_VERSION}$(lsb_release -cs) containerd.io && \
 	# Quick test of the Docker install
 	docker --version && \
 	rm -rf /var/lib/apt/lists/*

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 		software-properties-common && \
 	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
 	add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
-	apt-get install -y docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} containerd.io && \
+	apt-get install -y docker-ce=${DOCKER_VERSION}$(lsb_release -cs) docker-ce-cli=${DOCKER_VERSION}$(lsb_release -cs) containerd.io && \
 	# Quick test of the Docker install
 	docker --version && \
 	rm -rf /var/lib/apt/lists/*

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -1,6 +1,6 @@
 # vim:set ft=dockerfile:
 
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 LABEL maintainer="Community & Partner Engineering Team <community-partner@circleci.com>"
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -55,7 +55,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
-ENV DOCKER_VERSION 5:19.03.12~3-0~ubuntu-bionic
+ENV DOCKER_VERSION 5:19.03.12~3-0~ubuntu-
 RUN apt-get update && apt-get install -y \
 		apt-transport-https \
 		ca-certificates \
@@ -64,7 +64,7 @@ RUN apt-get update && apt-get install -y \
 		software-properties-common && \
 	curl -fsSL https://download.docker.com/linux/ubuntu/gpg | apt-key add - && \
 	add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable" && \
-	apt-get install -y docker-ce=${DOCKER_VERSION} docker-ce-cli=${DOCKER_VERSION} containerd.io && \
+	apt-get install -y docker-ce=${DOCKER_VERSION}$(lsb_release -cs) docker-ce-cli=${DOCKER_VERSION}$(lsb_release -cs) containerd.io && \
 	# Quick test of the Docker install
 	docker --version && \
 	rm -rf /var/lib/apt/lists/*

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ This includes but is not limited to:
 This image has the following tagging scheme:
 
 ```
-cimg/base:edge
-cimg/base:stable
-cimg/base:<YYYY.MM>
+cimg/base:edge[-version]
+cimg/base:stable[-version] 
+cimg/base:<YYYY.MM>[-version] 
 ```
 
 `edge` - This image tag points to the latest version of the Base image.
@@ -84,6 +84,14 @@ It is typically updated once a month.
 `<YYYY.MM>` - This image tag is a monthly snapshot of the image, referred to by the 4 digit year, dot, and a 2 digit month.
 For example `2019.09` would be the monthly snapshot tag from September 2019.
 This tag is intended for projects that are highly sensitive to changes and want the most deterministic builds possible.
+
+`-version` - This is an optional extension to the tag to specify the version of Ubuntu to use.
+There can be up to two options, the current LTS and the previous LTS.
+As of this writing, those options would be `18.04` or `20.04`.
+When leaving the version out, suggested, the default version will be used.
+The default Ubuntu version is the newest LTS version, after it has been out for 2 months.
+For example, Ubuntu 20.04 came out in April 2020, so it will become the default version for this image July 2020.
+The previous LTS version will be supported for a year after it drops out of the default slot.
 
 
 ## Development
@@ -129,11 +137,11 @@ Changes to this image should occur in the `Dockerfile.template` file and then us
 For example, you would run the following from the root of the repo:
 
 ```bash
-./shared/gen-dockerfiles.sh 18.04
+./shared/gen-dockerfiles.sh 18.04 20.04
 ```
 
-The generated Dockerfile will be located at `./18.04/Dockefile`.
-To build this image locally and try it out, you can run the following:
+The generated Dockerfile will be located at `./18.04/Dockefile` and `./20.04/Dockerfile`.
+To build the first image locally and try it out, you can run the following:
 
 ```bash
 cd 18.04
@@ -141,7 +149,7 @@ docker build -t test/base:18.04 .
 docker run -it test/base:18.04 bash
 ```
 
-While CircleCI will only be publishing LTS versions of Ubuntu (such as 18.04), you are free to swap out the version number with something newer for your own personal use.
+While CircleCI will only be publishing LTS versions of Ubuntu (such as 18.04 or 20.04), you are free to swap out the version number with something newer for your own personal use.
 
 ### Building the Dockerfiles
 

--- a/build-images.sh
+++ b/build-images.sh
@@ -1,3 +1,4 @@
 #!/usr/bin/env bash
 
 docker build --file 18.04/Dockerfile -t cimg/base:18.04 .
+docker build --file 20.04/Dockerfile -t cimg/base:20.04 .


### PR DESCRIPTION
Now that the shared-tools has support for multiple versions at once, we use that feature here to build both Ubuntu 18.04 and 20.04.

Closes #24.

To-Do:

- [x] validate this approach
- [x] decide on support time period for each version
- [x] update readme documentation in this repo
- [x] document this change in https://github.com/CircleCI-Public/cimg-overview