### PR TITLE
Fix LTS tags for stable and monthly snapshots.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -112,11 +112,11 @@ jobs:
             ./build-images.sh
             docker tag cimg/base:18.04 cimg/base:stable
             docker tag cimg/base:18.04 cimg/base:stable-18.04
-            docker tag cimg/base:18.04 cimg/base:stable-20.04
+            docker tag cimg/base:20.04 cimg/base:stable-20.04
             VERSION=$( date +%Y.%m )
             docker tag cimg/base:18.04 cimg/base:${VERSION}
             docker tag cimg/base:18.04 cimg/base:${VERSION}-18.04
-            docker tag cimg/base:18.04 cimg/base:${VERSION}-20.04
+            docker tag cimg/base:20.04 cimg/base:${VERSION}-20.04
       - deploy:
           name: "Publish Docker Images (master branch only)"
           command: |


### PR DESCRIPTION
Fixes the tags specified in the monthly snapshots. This has already been fixed (and confirmed) in production with the [monthly manual override tag](https://app.circleci.com/pipelines/github/CircleCI-Public/cimg-base/243/workflows/c760e700-b39a-42c4-9ebc-fb59d168c106).