### PR TITLE
Ubuntu 20.04 now default.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: "Build & Tag Images"
           command: |
             ./build-images.sh
-            docker tag cimg/base:18.04 cimg/base:edge
+            docker tag cimg/base:20.04 cimg/base:edge
             docker tag cimg/base:18.04 cimg/base:edge-18.04
             docker tag cimg/base:20.04 cimg/base:edge-20.04
       - deploy:
@@ -110,11 +110,11 @@ jobs:
           name: "Build & Tag Images"
           command: |
             ./build-images.sh
-            docker tag cimg/base:18.04 cimg/base:stable
+            docker tag cimg/base:20.04 cimg/base:stable
             docker tag cimg/base:18.04 cimg/base:stable-18.04
             docker tag cimg/base:20.04 cimg/base:stable-20.04
             VERSION=$( date +%Y.%m )
-            docker tag cimg/base:18.04 cimg/base:${VERSION}
+            docker tag cimg/base:20.04 cimg/base:${VERSION}
             docker tag cimg/base:18.04 cimg/base:${VERSION}-18.04
             docker tag cimg/base:20.04 cimg/base:${VERSION}-20.04
       - deploy:

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ There can be up to two options, the current LTS and the previous LTS.
 As of this writing, those options would be `18.04` or `20.04`.
 When leaving the version out, suggested, the default version will be used.
 The default Ubuntu version is the newest LTS version, after it has been out for 2 months.
-For example, Ubuntu 20.04 came out in April 2020, so it will become the default version for this image July 2020.
+For example, Ubuntu 20.04 came out in April 2020, so it will become the default version for this image September 2020.
 The previous LTS version will be supported for a year after it drops out of the default slot.
 
 


### PR DESCRIPTION
Closes #75.

As a reminder, for those using the base image directly, you can still use Ubuntu 18.04 by adding it to the tag. For example,

`cimg/base:stable-18.04`

This PR changes which Ubuntu version is used by default. Language Convenience Images will start to be based on Ubuntu 20.04 starting September 2nd. This only affects new image tags. Any existing tag will remain unchanged.