### PR TITLE
Update README for dev-hub parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ jobs:
 ```
 
 In the above example, the CircleCI Base Docker image is used for the primary container.
-More specifically, the tag `2020.01` indicates that the version of the base image used will be the January 2020 release.
+More specifically, the tag `2020.01` indicates the dated version of the base image.
 See how tags work below for more information.
 
 


### PR DESCRIPTION
In the dev-hub we are going to automatically sync the content from the cimg READMEs. 
As a part of the copy in the dev-hub, the semantic versions in the `Getting Started` header are going to be updated to the latest tag.  

https://circleci.com/developer/images/image/cimg/base
Currently, the sample config is updated with the latest version semver, but the description below it mentions the text here.
As we automatically sync the content, we're simply going to update the semver in the *entire header*. This change makes the content in the header make more sense.