### PR TITLE
Add pkg-config.

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# COnfigure environment
+# Configure environment
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci && \
 	apt-get update && apt-get install -y locales && \
@@ -43,6 +43,8 @@ RUN apt-get update && apt-get install -y \
 		netcat \
 		openssh-client \
 		parallel \
+		# compiling tool
+		pkg-config \
 		software-properties-common \
 		sudo \
 		tar \

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# COnfigure environment
+# Configure environment
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci && \
 	apt-get update && apt-get install -y locales && \
@@ -43,6 +43,8 @@ RUN apt-get update && apt-get install -y \
 		netcat \
 		openssh-client \
 		parallel \
+		# compiling tool
+		pkg-config \
 		software-properties-common \
 		sudo \
 		tar \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,7 +9,7 @@ SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
 ENV DEBIAN_FRONTEND=noninteractive
 
-# COnfigure environment
+# Configure environment
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	echo 'DPkg::Options "--force-confnew";' >> /etc/apt/apt.conf.d/90circleci && \
 	apt-get update && apt-get install -y locales && \
@@ -43,6 +43,8 @@ RUN apt-get update && apt-get install -y \
 		netcat \
 		openssh-client \
 		parallel \
+		# compiling tool
+		pkg-config \
 		software-properties-common \
 		sudo \
 		tar \


### PR DESCRIPTION
Adding the Apt package `pkg-config` to the pre-installed list. This is a compiling tool that should be helpful for many users. It's also pre-installed in Travis CI's environment.

Some info on pkg-config: https://linux.die.net/man/1/pkg-config

There was [a request for this package](https://github.com/CircleCI-Public/cimg-ruby/issues/55) for the Ruby image. Upon further review, we had it in the legacy Ruby image as an indirect installation. It's also available in the legacy buildpack-deps image. As that image will be deprecated and this image is the designated replacement, it makes sense to install this here.