### PR TITLE
Update Docker Compose to v1.28.3

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
-ENV DOCKER_VERSION 5:19.03.14~3-0~ubuntu-
+ENV DOCKER_VERSION 5:20.10.3~3-0~ubuntu-
 RUN apt-get update && apt-get install -y \
 		apt-transport-https \
 		ca-certificates \
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VERSION 1.28.2
+ENV COMPOSE_VERSION 1.28.3
 RUN curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
 	chmod +x /usr/local/bin/docker-compose && \
 	# Quick test of the Docker Compose install

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -78,7 +78,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
-ENV DOCKER_VERSION 5:19.03.14~3-0~ubuntu-
+ENV DOCKER_VERSION 5:20.10.3~3-0~ubuntu-
 RUN apt-get update && apt-get install -y \
 		apt-transport-https \
 		ca-certificates \
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VERSION 1.28.2
+ENV COMPOSE_VERSION 1.28.3
 RUN curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
 	chmod +x /usr/local/bin/docker-compose && \
 	# Quick test of the Docker Compose install

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -93,7 +93,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VERSION 1.28.2
+ENV COMPOSE_VERSION 1.28.3
 RUN curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose && \
 	chmod +x /usr/local/bin/docker-compose && \
 	# Quick test of the Docker Compose install


### PR DESCRIPTION
The main Docker version changed in the Dockerfiles because I forgot to generate them in that previous PR. Those are for the edge tag so it doesn't negatively impact anything.