### PR TITLE
Use smaller vim package.

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get update && apt-get install -y \
 		tzdata \
 		unzip \
 		# for ssh-enabled builds
-		vim \
+		vim-tiny \
 		wget \
 		zip && \
 	rm -rf /var/lib/apt/lists/*

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -72,7 +72,7 @@ RUN apt-get update && apt-get install -y \
 		tzdata \
 		unzip \
 		# for ssh-enabled builds
-		vim \
+		vim-tiny \
 		wget \
 		zip && \
 	rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -72,7 +72,7 @@ RUN apt-get update && apt-get install -y \
 		tzdata \
 		unzip \
 		# for ssh-enabled builds
-		vim \
+		vim-tiny \
 		wget \
 		zip && \
 	rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Related #97.

For the purpose of this image, the full vim package isn't needed. If and when this is used, it's only for SSH builds and `vim-tiny` satisfies the need.