### PR TITLE
Add zstd.

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -74,7 +74,8 @@ RUN apt-get update && apt-get install -y \
 		# for ssh-enabled builds
 		vim-tiny \
 		wget \
-		zip && \
+		zip \
+		zstd && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -74,7 +74,8 @@ RUN apt-get update && apt-get install -y \
 		# for ssh-enabled builds
 		vim-tiny \
 		wget \
-		zip && \
+		zip \
+		zstd && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -74,7 +74,8 @@ RUN apt-get update && apt-get install -y \
 		# for ssh-enabled builds
 		vim-tiny \
 		wget \
-		zip && \
+		zip \
+		zstd && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work


### PR DESCRIPTION
Is it possible to add zstd to the base image?

zstd is one of the best compression algorithms available today.
It is actually very good in terms of compression ratio and speed.
https://github.com/facebook/zstd

We use zstd in almost 100 repositories and install it every time.
Passing through zstd when saving_cache is a dozen seconds faster than gzip.
This was a speed advantage even if I installed zstd each time.

Image size increase by adding zstd is only about 3.5MB.

If this can be made available by default, it will improve the speed of CI.

Thank you for your consideration.