### PR TITLE
Update Dockerfile

### DIFF
--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -42,6 +42,7 @@ ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \
 
 RUN apt-get update && apt-get install -y \
 		autoconf \
+		amazon-ecr-credential-helper \
 		build-essential \
 		ca-certificates \
 		# already installed but hear for consistency


### PR DESCRIPTION
Add `amazon-ecr-credential-helper` a req'd tool for authenticating to AWS ECR.