### PR TITLE
Add PostgreSQL Client and update yq

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -64,6 +64,7 @@ RUN apt-get update && apt-get install -y \
 		parallel \
 		# compiling tool
 		pkg-config \
+		postgresql-client \
 		software-properties-common \
 		# already installed but hear for consistency
 		sudo \
@@ -99,7 +100,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSI
 	# Quick test of the Docker Compose install
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.13.3/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -64,6 +64,7 @@ RUN apt-get update && apt-get install -y \
 		parallel \
 		# compiling tool
 		pkg-config \
+		postgresql-client \
 		software-properties-common \
 		# already installed but hear for consistency
 		sudo \
@@ -99,7 +100,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSI
 	# Quick test of the Docker Compose install
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.13.3/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -64,6 +64,7 @@ RUN apt-get update && apt-get install -y \
 		parallel \
 		# compiling tool
 		pkg-config \
+		postgresql-client \
 		software-properties-common \
 		# already installed but hear for consistency
 		sudo \
@@ -99,7 +100,7 @@ RUN curl -L "https://github.com/docker/compose/releases/download/${COMPOSE_VERSI
 	# Quick test of the Docker Compose install
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.9.6/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.13.3/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 


### PR DESCRIPTION
I don't why to get into the habit of installing the clients for each database. The base image is big enough as is. I'm making an exception for PostgreSQL though because within the Convenience Images, it's usage is about 100 times higher than the other databases. That tells me that this will benefit at least 80% of database users, which is our guiding metric.

Closes #91.