### PR TITLE
Update Docker to v20.10.11

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
 		libmariadb-dev-compat \
 		# popular DB lib - PostgreSQL
 		libpq-dev \
+		libsqlite3-dev \
 		make \
 		# for ssh-enabled builds
 		nano \
@@ -81,7 +82,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
-ENV DOCKER_VERSION 5:20.10.9~3-0~ubuntu-
+ENV DOCKER_VERSION 5:20.10.11~3-0~ubuntu-
 RUN apt-get update && apt-get install -y \
 		apt-transport-https \
 		ca-certificates \

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
 		libmariadb-dev-compat \
 		# popular DB lib - PostgreSQL
 		libpq-dev \
+		libsqlite3-dev \
 		make \
 		# for ssh-enabled builds
 		nano \
@@ -81,7 +82,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
-ENV DOCKER_VERSION 5:20.10.9~3-0~ubuntu-
+ENV DOCKER_VERSION 5:20.10.11~3-0~ubuntu-
 RUN apt-get update && apt-get install -y \
 		apt-transport-https \
 		ca-certificates \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -82,7 +82,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
-ENV DOCKER_VERSION 5:20.10.9~3-0~ubuntu-
+ENV DOCKER_VERSION 5:20.10.11~3-0~ubuntu-
 RUN apt-get update && apt-get install -y \
 		apt-transport-https \
 		ca-certificates \


### PR DESCRIPTION
The libsqllite line is because I didn't regenerate the Ubuntu versions properly in one of my recent PRs. So it's okay that it shows up here. The main PR focus is the new Docker release.