### PR TITLE
Fix Docker Compose v2 Installation

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -98,9 +98,10 @@ RUN apt-get update && apt-get install -y \
 
 # Install Docker Compose - see prerequisite above
 ENV COMPOSE_VERSION 2.2.2
-RUN mkdir -p ~/.docker/cli-plugins/ && \
-	curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/.docker/cli-plugins/docker-compose && \
-	chmod +x ~/.docker/cli-plugins/docker-compose && \
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	mkdir -p $dockerPluginDir && \
+	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	chmod +x $dockerPluginDir/docker-compose && \
 	# Quick test of the Docker Compose install
 	docker compose version
 

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -98,9 +98,10 @@ RUN apt-get update && apt-get install -y \
 
 # Install Docker Compose - see prerequisite above
 ENV COMPOSE_VERSION 2.2.2
-RUN mkdir -p ~/.docker/cli-plugins/ && \
-	curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/.docker/cli-plugins/docker-compose && \
-	chmod +x ~/.docker/cli-plugins/docker-compose && \
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	mkdir -p $dockerPluginDir && \
+	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	chmod +x $dockerPluginDir/docker-compose && \
 	# Quick test of the Docker Compose install
 	docker compose version
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -98,9 +98,10 @@ RUN apt-get update && apt-get install -y \
 
 # Install Docker Compose - see prerequisite above
 ENV COMPOSE_VERSION 2.2.2
-RUN mkdir -p ~/.docker/cli-plugins/ && \
-	curl -sSL "https://github.com/docker/compose/releases/download/${COMPOSE_VERSION}/docker-compose-$(uname -s)-$(uname -m)" -o ~/.docker/cli-plugins/docker-compose && \
-	chmod +x ~/.docker/cli-plugins/docker-compose && \
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	mkdir -p $dockerPluginDir && \
+	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	chmod +x $dockerPluginDir/docker-compose && \
 	# Quick test of the Docker Compose install
 	docker compose version
 


### PR DESCRIPTION
The initial PR worked... for some reason. I think the capitalization of the OS (i.e. Linux) changed in the download links. This PR corrects that and uses the OS-wide plugin location instead of the one for the root user.

If anyone still wants to use Docker Compose v1 btw, the suggested path is to install it with the [Docker Orb](https://circleci.com/developer/orbs/orb/circleci/docker#commands-install-docker-compose).