### PR TITLE
Add libssl-dev

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
 		libmariadb-dev-compat \
 		# popular DB lib - PostgreSQL
 		libpq-dev \
+		libssl-dev \
 		libsqlite3-dev \
 		make \
 		# for ssh-enabled builds

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
 		libmariadb-dev-compat \
 		# popular DB lib - PostgreSQL
 		libpq-dev \
+		libssl-dev \
 		libsqlite3-dev \
 		make \
 		# for ssh-enabled builds

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -57,6 +57,7 @@ RUN apt-get update && apt-get install -y \
 		libmariadb-dev-compat \
 		# popular DB lib - PostgreSQL
 		libpq-dev \
+		libssl-dev \
 		libsqlite3-dev \
 		make \
 		# for ssh-enabled builds


### PR DESCRIPTION
This is updating a package that's already installed. This will force the update to make sure it's newer, which is good for security packages. In particular, Rust users were reporting some problems but this is also helpful for the buildpack-deps transition.