### PR TITLE
Updates to outdated versioning and tools

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,7 @@ workflows:
 jobs:
   test:
     docker:
-      - image: cimg/base:2022.01
+      - image: cimg/base@sha256:9d94b570bdd6809833d5e12d2ca1cb56de77d71dfe1d7e2fe44070b7fbbed048
     steps:
       - checkout
       - setup_remote_docker:
@@ -94,7 +94,7 @@ jobs:
 
   publish-edge:
     docker:
-      - image: cimg/base:2022.01
+      - image: cimg/base@sha256:9d94b570bdd6809833d5e12d2ca1cb56de77d71dfe1d7e2fe44070b7fbbed048
     steps:
       - checkout
       - setup_remote_docker:
@@ -118,7 +118,7 @@ jobs:
 
   publish-monthly:
     docker:
-      - image: cimg/base:2022.01
+      - image: cimg/base@sha256:9d94b570bdd6809833d5e12d2ca1cb56de77d71dfe1d7e2fe44070b7fbbed048
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,8 @@ workflows:
 jobs:
   test:
     docker:
-      - image: cimg/base@sha256:9d94b570bdd6809833d5e12d2ca1cb56de77d71dfe1d7e2fe44070b7fbbed048
+      # references for this digest refers to cimg/base:2022.01
+      - image: cimg/base@sha256:bf1a115683b4b0366dce294accf87ba967b9ad0d78f29d974b71dc7e79ffbee2
     steps:
       - checkout
       - setup_remote_docker:
@@ -94,7 +95,7 @@ jobs:
 
   publish-edge:
     docker:
-      - image: cimg/base@sha256:9d94b570bdd6809833d5e12d2ca1cb56de77d71dfe1d7e2fe44070b7fbbed048
+      - image: cimg/base@sha256:bf1a115683b4b0366dce294accf87ba967b9ad0d78f29d974b71dc7e79ffbee2
     steps:
       - checkout
       - setup_remote_docker:
@@ -118,7 +119,7 @@ jobs:
 
   publish-monthly:
     docker:
-      - image: cimg/base@sha256:9d94b570bdd6809833d5e12d2ca1cb56de77d71dfe1d7e2fe44070b7fbbed048
+      - image: cimg/base@sha256:bf1a115683b4b0366dce294accf87ba967b9ad0d78f29d974b71dc7e79ffbee2
     steps:
       - checkout
       - setup_remote_docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -71,7 +71,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: "20.10.12"
+          version: "20.10.11"
       - run:
           name: "Build Dockerfiles"
           command: |
@@ -98,7 +98,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: "20.10.12"
+          version: "20.10.11"
       - run:
           name: "Build & Tag Images"
           command: |
@@ -122,7 +122,7 @@ jobs:
     steps:
       - checkout
       - setup_remote_docker:
-          version: "20.10.12"
+          version: "20.10.11"
       - run:
           name: "Build & Tag Images"
           command: |

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,11 @@ workflows:
 jobs:
   test:
     docker:
-      - image: cibuilds/docker:19.03
+      - image: cimg/base:2022.01
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: "20.10.12"
       - run:
           name: "Build Dockerfiles"
           command: |
@@ -85,20 +85,20 @@ jobs:
               echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
 
               # Update the Docker Hub description
-              STUBB_VER=0.2.0
-              STUBB_URL="https://github.com/CircleCI-Public/stubb/releases/download/v${STUBB_VER}/stubb_${STUBB_VER}-linux-amd64.tar.gz"
-              curl -sSL $STUBB_URL | tar -xz -C /usr/local/bin stubb
+              SONAR_VER=0.15.0
+              SONAR_URL="https://github.com/felicianotech/sonar/releases/download/v${SONAR_VER}/sonar-v${SONAR_VER}-linux-amd64.tar.gz"
+              curl -sSL $SONAR_URL | tar -xz -C /usr/local/bin sonar
 
-              stubb set description cimg/base ./README.md
+              sonar set description cimg/base ./README.md
             fi
 
   publish-edge:
     docker:
-      - image: cibuilds/docker:19.03
+      - image: cimg/base:2022.01
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: "20.10.12"
       - run:
           name: "Build & Tag Images"
           command: |
@@ -118,11 +118,11 @@ jobs:
 
   publish-monthly:
     docker:
-      - image: cibuilds/docker:19.03
+      - image: cimg/base:2022.01
     steps:
       - checkout
       - setup_remote_docker:
-          version: 20.10.2
+          version: "20.10.12"
       - run:
           name: "Build & Tag Images"
           command: |


### PR DESCRIPTION
- cibuilds/docker -> cimg/base:2022.01 image digest
- Updating the setup_remote_docker version from 19 -> 20.10.11; latest version supported
- Subbed out Stubb for Sonar; an updated tool that performs the functions of Stubb
