### PR TITLE
update yq to v4.20.1

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -116,7 +116,7 @@ RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	# Tests if docker-compose for v1 is transposed to v2
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.16.2/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.20.1/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 


### PR DESCRIPTION
v4.18.1 introduced some new default behavior that appears to be a breaking change. Updating to the latest version yq v4.20.1.

**This is the issue this resolves:**

```shell
# (in test file review.bats, line 10)
#   `result=$(cat ${REVIEW_TEST_DIR}src/@orb.yml | yq '.display.source_url' )' failed
# Error: unknown command ".display.source_url" for "yq"
# Run 'yq --help' for usage.
```

It seems here that the current version of yq may require `-e`, but newer versions since 4.18.1 no longer require this. Manually updating the YQ version inside the docker container appears to have resolved the issue.

**With resolution:**

Here is me running a series of bats tests which are attempting to use YQ, now using the newest version.
<img width="712" alt="image" src="https://user-images.githubusercontent.com/33272306/154310119-35920d08-15f2-4f19-9f03-76b1237ec6b0.png">
