### PR TITLE
Set dumb terminal envars

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -9,7 +9,9 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 # Change default shell for RUN from Dash to Bash
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    TERM=dumb \
+    PAGER=cat
 
 # Configure environment
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -9,7 +9,9 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 # Change default shell for RUN from Dash to Bash
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    TERM=dumb \
+    PAGER=cat
 
 # Configure environment
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -9,7 +9,9 @@ LABEL maintainer="Community & Partner Engineering Team <community-partner@circle
 # Change default shell for RUN from Dash to Bash
 SHELL ["/bin/bash", "-exo", "pipefail", "-c"]
 
-ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBIAN_FRONTEND=noninteractive \
+    TERM=dumb \
+    PAGER=cat
 
 # Configure environment
 RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \


### PR DESCRIPTION
These are environment variables that help tell applications what kind of environment we're running. This will be set (if not already) in the Linux VM images as well. This was partially inspired by this [CircleCI Discuss post](https://discuss.circleci.com/t/upgrading-from-deprecated-docker-convenience-image-openjdk-connecting-to-postgres/43356/2?u=felicianotech).