### PR TITLE
Opt out of git's new security feature

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -127,6 +127,10 @@ RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linu
 	mv /usr/local/bin/yq{_linux_amd64,}
 
 USER circleci
+# Run commands and tests as circleci user
+RUN whoami && \
+	# opt-out of the new security feature, not needed in a CI environment
+	git config --global --add safe.directory '*'
 
 # Match the default CircleCI working directory
 WORKDIR /home/circleci/project

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -127,6 +127,10 @@ RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linu
 	mv /usr/local/bin/yq{_linux_amd64,}
 
 USER circleci
+# Run commands and tests as circleci user
+RUN whoami && \
+	# opt-out of the new security feature, not needed in a CI environment
+	git config --global --add safe.directory '*'
 
 # Match the default CircleCI working directory
 WORKDIR /home/circleci/project

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -127,6 +127,10 @@ RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linu
 	mv /usr/local/bin/yq{_linux_amd64,}
 
 USER circleci
+# Run commands and tests as circleci user
+RUN whoami && \
+	# opt-out of the new security feature, not needed in a CI environment
+	git config --global --add safe.directory '*'
 
 # Match the default CircleCI working directory
 WORKDIR /home/circleci/project

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -127,6 +127,10 @@ RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.23.1/yq_linu
 	mv /usr/local/bin/yq{_linux_amd64,}
 
 USER circleci
+# Run commands and tests as circleci user
+RUN whoami && \
+	# opt-out of the new security feature, not needed in a CI environment
+	git config --global --add safe.directory '*'
 
 # Match the default CircleCI working directory
 WORKDIR /home/circleci/project


### PR DESCRIPTION
Git fixed a [CVE announced in April](https://github.blog/2022-04-12-git-security-vulnerability-announced/) thought caused an unintended side effect for some CircleCI (and other CI provider) users. This PR opts-out of the new security change since it doesn't apply in our environment anyway.

This allows the checkout step to clone to a directory such as `/mnt/ramdisk` for example.

This change will land in `edge` after this is merged and will land in `current` in the `2022.06` release in just over a week.

Fixes #170.