### PR TITLE
vim-tiny was missing vim features

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -86,13 +86,11 @@ RUN noInstallRecommends="" && \
 		tzdata \
 		unzip \
 		# for ssh-enabled builds
-		vim-tiny \
+		vim \
 		wget \
 		zip && \
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
-	rm -rf /var/lib/apt/lists/* && \
-	# vim-tiny doesn't include a vim binary even though it includes vim
-	ln -s /usr/bin/vi /usr/bin/vim
+	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
 ENV DOCKER_VERSION 5:20.10.14~3-0~ubuntu-

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -86,13 +86,11 @@ RUN noInstallRecommends="" && \
 		tzdata \
 		unzip \
 		# for ssh-enabled builds
-		vim-tiny \
+		vim \
 		wget \
 		zip && \
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
-	rm -rf /var/lib/apt/lists/* && \
-	# vim-tiny doesn't include a vim binary even though it includes vim
-	ln -s /usr/bin/vi /usr/bin/vim
+	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
 ENV DOCKER_VERSION 5:20.10.14~3-0~ubuntu-

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -86,13 +86,11 @@ RUN noInstallRecommends="" && \
 		tzdata \
 		unzip \
 		# for ssh-enabled builds
-		vim-tiny \
+		vim \
 		wget \
 		zip && \
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
-	rm -rf /var/lib/apt/lists/* && \
-	# vim-tiny doesn't include a vim binary even though it includes vim
-	ln -s /usr/bin/vi /usr/bin/vim
+	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
 ENV DOCKER_VERSION 5:20.10.14~3-0~ubuntu-

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -86,13 +86,11 @@ RUN noInstallRecommends="" && \
 		tzdata \
 		unzip \
 		# for ssh-enabled builds
-		vim-tiny \
+		vim \
 		wget \
 		zip && \
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
-	rm -rf /var/lib/apt/lists/* && \
-	# vim-tiny doesn't include a vim binary even though it includes vim
-	ln -s /usr/bin/vi /usr/bin/vim
+	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work
 ENV DOCKER_VERSION 5:20.10.14~3-0~ubuntu-


### PR DESCRIPTION
We initially switched to the vim-tiny package because it used less disk space than the vim package. Unfortunately, vim-tiny is more like vi rather than vim without extra plugins, etc.