### PR TITLE
Remove deprecated stable tag

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -135,9 +135,6 @@ jobs:
             docker tag cimg/base:18.04 cimg/base:current-18.04
             docker tag cimg/base:20.04 cimg/base:current-20.04
             docker tag cimg/base:22.04 cimg/base:current-22.04
-            docker tag cimg/base:20.04 cimg/base:stable
-            docker tag cimg/base:18.04 cimg/base:stable-18.04
-            docker tag cimg/base:20.04 cimg/base:stable-20.04
             VERSION=$( date +%Y.%m )
             docker tag cimg/base:20.04 cimg/base:${VERSION}
             docker tag cimg/base:18.04 cimg/base:${VERSION}-18.04
@@ -152,9 +149,6 @@ jobs:
               docker push cimg/base:current-18.04
               docker push cimg/base:current-20.04
               docker push cimg/base:current-22.04
-              docker push cimg/base:stable
-              docker push cimg/base:stable-18.04
-              docker push cimg/base:stable-20.04
               VERSION=$( date +%Y.%m )
               docker push cimg/base:${VERSION}
               docker push cimg/base:${VERSION}-18.04
@@ -165,9 +159,6 @@ jobs:
               docker push cimg/base:current-18.04
               docker push cimg/base:current-20.04
               docker push cimg/base:current-22.04
-              docker push cimg/base:stable
-              docker push cimg/base:stable-18.04
-              docker push cimg/base:stable-20.04
               VERSION=$( date +%Y.%m )
               docker push cimg/base:${VERSION}
               docker push cimg/base:${VERSION}-18.04


### PR DESCRIPTION
The `stable` tag was deprecated awhile back. `current` was its replacement. This finally removes it from the build.