### PR TITLE
Revert "Use new Docker Compose installation method"

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -108,14 +108,12 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-# Even though they use the same repo, Docker Compose is installed seperately
-# from Docker Engine due to the fact that Docker Compose releases much more
-# frequently. This is a caching decision.
-ENV COMPOSE_VER 2.6.0
+ENV COMPOSE_VERSION 2.4.1
 ENV COMPOSE_SWITCH_VERSION 1.0.4
-RUN apt-get update && apt-get install --yes --no-install-recommends \
-		docker-compose-plugin=${COMPOSE_VER}~ubuntu-$( lsb_release -cs ) \
-	&& \
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	mkdir -p $dockerPluginDir && \
+	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	chmod +x $dockerPluginDir/docker-compose && \
 	curl -fL https://github.com/docker/compose-switch/releases/download/v${COMPOSE_SWITCH_VERSION}/docker-compose-linux-amd64 -o /usr/local/bin/compose-switch && \
 	# Quick test of the Docker Compose install
 	docker compose version && \

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -108,14 +108,12 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-# Even though they use the same repo, Docker Compose is installed seperately
-# from Docker Engine due to the fact that Docker Compose releases much more
-# frequently. This is a caching decision.
-ENV COMPOSE_VER 2.6.0
+ENV COMPOSE_VERSION 2.4.1
 ENV COMPOSE_SWITCH_VERSION 1.0.4
-RUN apt-get update && apt-get install --yes --no-install-recommends \
-		docker-compose-plugin=${COMPOSE_VER}~ubuntu-$( lsb_release -cs ) \
-	&& \
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	mkdir -p $dockerPluginDir && \
+	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	chmod +x $dockerPluginDir/docker-compose && \
 	curl -fL https://github.com/docker/compose-switch/releases/download/v${COMPOSE_SWITCH_VERSION}/docker-compose-linux-amd64 -o /usr/local/bin/compose-switch && \
 	# Quick test of the Docker Compose install
 	docker compose version && \

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -108,14 +108,12 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-# Even though they use the same repo, Docker Compose is installed seperately
-# from Docker Engine due to the fact that Docker Compose releases much more
-# frequently. This is a caching decision.
-ENV COMPOSE_VER 2.6.0
+ENV COMPOSE_VERSION 2.4.1
 ENV COMPOSE_SWITCH_VERSION 1.0.4
-RUN apt-get update && apt-get install --yes --no-install-recommends \
-		docker-compose-plugin=${COMPOSE_VER}~ubuntu-$( lsb_release -cs ) \
-	&& \
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	mkdir -p $dockerPluginDir && \
+	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	chmod +x $dockerPluginDir/docker-compose && \
 	curl -fL https://github.com/docker/compose-switch/releases/download/v${COMPOSE_SWITCH_VERSION}/docker-compose-linux-amd64 -o /usr/local/bin/compose-switch && \
 	# Quick test of the Docker Compose install
 	docker compose version && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -108,14 +108,12 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-# Even though they use the same repo, Docker Compose is installed seperately
-# from Docker Engine due to the fact that Docker Compose releases much more
-# frequently. This is a caching decision.
-ENV COMPOSE_VER 2.6.0
+ENV COMPOSE_VERSION 2.4.1
 ENV COMPOSE_SWITCH_VERSION 1.0.4
-RUN apt-get update && apt-get install --yes --no-install-recommends \
-		docker-compose-plugin=${COMPOSE_VER}~ubuntu-$( lsb_release -cs ) \
-	&& \
+RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
+	mkdir -p $dockerPluginDir && \
+	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VERSION}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \
+	chmod +x $dockerPluginDir/docker-compose && \
 	curl -fL https://github.com/docker/compose-switch/releases/download/v${COMPOSE_SWITCH_VERSION}/docker-compose-linux-amd64 -o /usr/local/bin/compose-switch && \
 	# Quick test of the Docker Compose install
 	docker compose version && \


### PR DESCRIPTION
Reverts CircleCI-Public/cimg-base#178

This was an exciting idea when we found out that Docker started including Docker Compose in the apt repository. Unfortunately, this new install method is not working out for us. Docker doesn't publish new Docker Compose releases to the repo until they do a new Docker release. This is preventing us from releasing new Docker Compose versions within our image itself. I have an [open issue](https://github.com/docker/compose/issues/9657) upstream regarding this.

Until that gets resolved at some point, we'll go back to how we use to install Docker Compose. Not as "cool", but it worked.