### PR TITLE
Adjust for monthly scheduled pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,23 +10,11 @@ workflows:
     when: << pipeline.parameters.cron >>
     # Publishes the `YYYY.MM` tag as well as the `current` tag
     jobs:
-      - schedule-fix:
-          filters:
-            branches:
-              ignore: /.*/
       - test:
-          requires:
-            - schedule-fix
-          filters:
-            branches:
-              ignore: /.*/
           context: cimg-publishing
       - publish-monthly:
           requires:
             - test
-          filters:
-            branches:
-              ignore: /.*/
           context: cimg-publishing
   main:
     when:


### PR DESCRIPTION
This PR cleans up the config a bit. The main change was actually done in the CircleCI UI where we are finally able to enable **monthly** scheduled pipelines.

The monthly snapshot builds are currently set to run on the 2nd of the month at 10:00 UTC.