### PR TITLE
Upgrade Dockerize to v0.8.0

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -30,14 +30,12 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 
-	# Install Dockerize v0.6.1
-	# Source repo: https://github.com/jwilder/dockerize
-	# I (Ricardo) would like to replace this one day. It's a tool not really
-	# maintained and we can likely offer something better.
-	curl -sSL --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz "https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" && \
-	tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz && \
-	rm -rf /tmp/dockerize-linux-amd64.tar.gz && \
-	# Quick test of Dockerize
+	dockerizeArch=ard64 && \
+	if uname -p | grep "x86_64"; then \
+		dockerizeArch=x86_64; \
+	fi && \
+	curl -sSL --fail --retry 3 --output /usr/local/bin/dockerize "https://github.com/powerman/dockerize/releases/download/v0.8.0/dockerize-linux-${dockerizeArch}" && \
+	chmod +x /usr/local/bin/dockerize && \
 	dockerize --version
 
 ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -30,14 +30,12 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 
-	# Install Dockerize v0.6.1
-	# Source repo: https://github.com/jwilder/dockerize
-	# I (Ricardo) would like to replace this one day. It's a tool not really
-	# maintained and we can likely offer something better.
-	curl -sSL --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz "https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" && \
-	tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz && \
-	rm -rf /tmp/dockerize-linux-amd64.tar.gz && \
-	# Quick test of Dockerize
+	dockerizeArch=ard64 && \
+	if uname -p | grep "x86_64"; then \
+		dockerizeArch=x86_64; \
+	fi && \
+	curl -sSL --fail --retry 3 --output /usr/local/bin/dockerize "https://github.com/powerman/dockerize/releases/download/v0.8.0/dockerize-linux-${dockerizeArch}" && \
+	chmod +x /usr/local/bin/dockerize && \
 	dockerize --version
 
 ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -30,14 +30,12 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 
-	# Install Dockerize v0.6.1
-	# Source repo: https://github.com/jwilder/dockerize
-	# I (Ricardo) would like to replace this one day. It's a tool not really
-	# maintained and we can likely offer something better.
-	curl -sSL --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz "https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" && \
-	tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz && \
-	rm -rf /tmp/dockerize-linux-amd64.tar.gz && \
-	# Quick test of Dockerize
+	dockerizeArch=ard64 && \
+	if uname -p | grep "x86_64"; then \
+		dockerizeArch=x86_64; \
+	fi && \
+	curl -sSL --fail --retry 3 --output /usr/local/bin/dockerize "https://github.com/powerman/dockerize/releases/download/v0.8.0/dockerize-linux-${dockerizeArch}" && \
+	chmod +x /usr/local/bin/dockerize && \
 	dockerize --version
 
 ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -30,14 +30,12 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 
-	# Install Dockerize v0.6.1
-	# Source repo: https://github.com/jwilder/dockerize
-	# I (Ricardo) would like to replace this one day. It's a tool not really
-	# maintained and we can likely offer something better.
-	curl -sSL --fail --retry 3 --output /tmp/dockerize-linux-amd64.tar.gz "https://circle-downloads.s3.amazonaws.com/circleci-images/cache/linux-amd64/dockerize-latest.tar.gz" && \
-	tar -C /usr/local/bin -xzvf /tmp/dockerize-linux-amd64.tar.gz && \
-	rm -rf /tmp/dockerize-linux-amd64.tar.gz && \
-	# Quick test of Dockerize
+	dockerizeArch=ard64 && \
+	if uname -p | grep "x86_64"; then \
+		dockerizeArch=x86_64; \
+	fi && \
+	curl -sSL --fail --retry 3 --output /usr/local/bin/dockerize "https://github.com/powerman/dockerize/releases/download/v0.8.0/dockerize-linux-${dockerizeArch}" && \
+	chmod +x /usr/local/bin/dockerize && \
 	dockerize --version
 
 ENV PATH=/home/circleci/bin:/home/circleci/.local/bin:$PATH \


### PR DESCRIPTION
Fixes #198 

This Dockerize update is mainly being done in preparation for upcoming arm64 image support. The current version we were using was amd64 only. Diving a bit deeper though...

The version of Dockerize we've been using has been stuck in time. For two reasons. 1) The original project, https://github.com/jwilder/dockerize, is no longer maintained. So there hasn't been new releases. 2) We were using a release from the project stored in our S3 bucket.

We're switching to a fork that has been accepted by many on the community. Relevant is this [GitHub Issue](https://github.com/docker/docker.github.io/issues/13548) in the official Docker Docs as well as this [follow up PR](https://github.com/docker/docker.github.io/pull/13549) that actually makes the suggestion change over to this newer project. We're switching to this fork.

v0.8.0 was chosen for a specific reason. I don't want to jump straight to v0.16.3 in case there are breaking changes we're not aware of. I rather ease into that change over time. I wanted to use a version much closer to v0.6.1 from the original project. v0.8.0 of the fork is the closest version that was also compiled for arm64, which we need.