### PR TITLE
Prep new monthly release

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,38 +116,12 @@ jobs:
       - run:
           name: "Build & Tag Images"
           command: |
-            ./build-images.sh
-            docker tag cimg/base:18.04 cimg/base:current-18.04
-            docker tag cimg/base:20.04 cimg/base:current-20.04
-            docker tag cimg/base:22.04 cimg/base:current-22.04
-            docker tag cimg/base:22.04 cimg/base:current
-            VERSION=$( date +%Y.%m )
-            docker tag cimg/base:18.04 cimg/base:${VERSION}-18.04
-            docker tag cimg/base:20.04 cimg/base:${VERSION}-20.04
-            docker tag cimg/base:22.04 cimg/base:${VERSION}-22.04
-            docker tag cimg/base:22.04 cimg/base:${VERSION}
+            # This script is currently edited by hand
+            ./build-monthly-images.sh
       - deploy:
           name: "Publish Docker Images (main branch only)"
           command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+            if [ "${CIRCLE_BRANCH}" == "main" ] || [ "${CIRCLE_TAG}" == "monthly" ]; then
               echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-              docker push cimg/base:current-18.04
-              docker push cimg/base:current-20.04
-              docker push cimg/base:current-22.04
-              docker push cimg/base:current
-              VERSION=$( date +%Y.%m )
-              docker push cimg/base:${VERSION}-18.04
-              docker push cimg/base:${VERSION}-20.04
-              docker push cimg/base:${VERSION}
-            elif [ "${CIRCLE_TAG}" == "monthly" ]; then
-              echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-              docker push cimg/base:current-18.04
-              docker push cimg/base:current-20.04
-              docker push cimg/base:current-22.04
-              docker push cimg/base:current
-              VERSION=$( date +%Y.%m )
-              docker push cimg/base:${VERSION}-18.04
-              docker push cimg/base:${VERSION}-20.04
-              docker push cimg/base:${VERSION}-22.04
-              docker push cimg/base:${VERSION}
+              ./push-monthly-images.sh
             fi

--- a/build-monthly-images.sh
+++ b/build-monthly-images.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Do not edit by hand; please use build scripts/templates to make changes
+
+docker context create cimg
+docker buildx create --use cimg
+
+VERSION=$( date +%Y.%m )
+
+echo "The 'version' is ${VERSION}"
+
+docker buildx build --platform=linux/amd64,linux/arm64 --file 18.04/Dockerfile -t cimg/base:${VERSION}-18.04 -t cimg/base:current-18.04 .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 20.04/Dockerfile -t cimg/base:${VERSION}-20.04 -t cimg/base:current-20.04 .
+docker buildx build --platform=linux/amd64,linux/arm64 --file 22.04/Dockerfile -t cimg/base:${VERSION}-22.04 -t cimg/base:${VERSION} -t cimg/base:current-22.04 -t cimg/base:current .

--- a/push-monthly-images.sh
+++ b/push-monthly-images.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+# Do not edit by hand; please use build scripts/templates to make changes
+
+docker context create cimg
+docker buildx create --use cimg
+
+VERSION=$( date +%Y.%m )
+
+docker buildx build --push --platform=linux/amd64,linux/arm64 --file 18.04/Dockerfile -t cimg/base:${VERSION}-18.04 -t cimg/base:current-18.04 .
+docker buildx build --push --platform=linux/amd64,linux/arm64 --file 20.04/Dockerfile -t cimg/base:${VERSION}-20.04 -t cimg/base:current-20.04 .
+docker buildx build --push --platform=linux/amd64,linux/arm64 --file 22.04/Dockerfile -t cimg/base:${VERSION}-22.04 -t cimg/base:${VERSION} -t cimg/base:current-22.04 -t cimg/base:current .


### PR DESCRIPTION
This includes the work needed to publish the monthly updates but with support for arm64 images. This work is partially manual and doesn't fit in with the fully automated system we normally use for cimg-shared. This is okay for now because:

1. it's temporary as work continues in cimg-shared for better arm support
2. This image was always slightly an oddball anyway since it's the base image.

I'm hoping this have this system more automated by the November release.