### PR TITLE
Match user/group IDs to VM images for consistency

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -24,7 +24,8 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
 
-	useradd --uid=3434 --user-group --create-home circleci && \
+	groupadd --gid=1002 circleci && \
+	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
 	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
 	sudo -u circleci mkdir /home/circleci/project && \

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -24,7 +24,8 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
 
-	useradd --uid=3434 --user-group --create-home circleci && \
+	groupadd --gid=1002 circleci && \
+	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
 	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
 	sudo -u circleci mkdir /home/circleci/project && \

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -24,7 +24,8 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
 
-	useradd --uid=3434 --user-group --create-home circleci && \
+	groupadd --gid=1002 circleci && \
+	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
 	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
 	sudo -u circleci mkdir /home/circleci/project && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -24,7 +24,8 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
 
-	useradd --uid=3434 --user-group --create-home circleci && \
+	groupadd --gid=1002 circleci && \
+	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
 	echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep && \
 	sudo -u circleci mkdir /home/circleci/project && \


### PR DESCRIPTION
Closes #122

This makes the Convenience Images and VM images consistent when it comes to the `circleci` user. A great example of how this is useful is from #122. Using workspaces to move files around between executors will work much more easily with this change.