### PR TITLE
Add git-lfs support to the git client

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -23,7 +23,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	&& \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
-
+	\
 	groupadd --gid=1002 circleci && \
 	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
@@ -31,7 +31,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 	sudo -u circleci mkdir -p /home/circleci/.local/bin && \
-
+	\
 	dockerizeArch=arm64 && \
 	if uname -p | grep "x86_64"; then \
 		dockerizeArch=x86_64; \
@@ -89,7 +89,10 @@ RUN noInstallRecommends="" && \
 		vim \
 		wget \
 		zip && \
+	# get the semi-official latest-stable git instead of using the old(er) version from the ubuntu distro
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
+	# get the semi-official latest-stable git-lfs too
+	curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -23,7 +23,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	&& \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
-
+	\
 	groupadd --gid=1002 circleci && \
 	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
@@ -31,7 +31,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 	sudo -u circleci mkdir -p /home/circleci/.local/bin && \
-
+	\
 	dockerizeArch=arm64 && \
 	if uname -p | grep "x86_64"; then \
 		dockerizeArch=x86_64; \
@@ -89,7 +89,10 @@ RUN noInstallRecommends="" && \
 		vim \
 		wget \
 		zip && \
+	# get the semi-official latest-stable git instead of using the old(er) version from the ubuntu distro
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
+	# get the semi-official latest-stable git-lfs too
+	curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -23,7 +23,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	&& \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
-
+	\
 	groupadd --gid=1002 circleci && \
 	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
@@ -31,7 +31,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 	sudo -u circleci mkdir -p /home/circleci/.local/bin && \
-
+	\
 	dockerizeArch=arm64 && \
 	if uname -p | grep "x86_64"; then \
 		dockerizeArch=x86_64; \
@@ -89,7 +89,10 @@ RUN noInstallRecommends="" && \
 		vim \
 		wget \
 		zip && \
+	# get the semi-official latest-stable git instead of using the old(er) version from the ubuntu distro
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
+	# get the semi-official latest-stable git-lfs too
+	curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -23,7 +23,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	&& \
 	locale-gen en_US.UTF-8 && \
 	rm -rf /var/lib/apt/lists/* && \
-
+	\
 	groupadd --gid=1002 circleci && \
 	useradd --uid=1001 --gid=circleci --create-home circleci && \
 	echo 'circleci ALL=NOPASSWD: ALL' >> /etc/sudoers.d/50-circleci && \
@@ -31,7 +31,7 @@ RUN echo 'APT::Get::Assume-Yes "true";' > /etc/apt/apt.conf.d/90circleci && \
 	sudo -u circleci mkdir /home/circleci/project && \
 	sudo -u circleci mkdir /home/circleci/bin && \
 	sudo -u circleci mkdir -p /home/circleci/.local/bin && \
-
+	\
 	dockerizeArch=arm64 && \
 	if uname -p | grep "x86_64"; then \
 		dockerizeArch=x86_64; \
@@ -89,7 +89,10 @@ RUN noInstallRecommends="" && \
 		vim \
 		wget \
 		zip && \
+	# get the semi-official latest-stable git instead of using the old(er) version from the ubuntu distro
 	add-apt-repository ppa:git-core/ppa && apt-get install -y git && \
+	# get the semi-official latest-stable git-lfs too
+	curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work


### PR DESCRIPTION
TL;DR: `apt-get install git-lfs`
Closes #180

## What is it?

Git's answer to the problems of having large files in a git repository is git-lfs.

## Why do we care?

Since git is core to how CircleCI works, and since git-lfs is core to how git handles large files, many customers will need this.
Any repo might be using git-lfs; it's typically installed "by default" in development environments etc such that user's might not even be aware of its presence.
Some git repo providers (e.g. GitHub) even force users to use it for files over a certain size.

However, IF a CircleCI build does a `checkout` on a repository that contains git-lfs files AND the git client is _missing_ support for git-lfs THEN it does not fail, it just runs the build with a corrupted workspace, with the "lfs files" being left as (small) references to git-lfs content instead of being the actual files they should be.
Silent failures are bad - unless the customer's build also includes some form of test to verify the integrity of the data it got from git, it could result in a corrupted build result being published.

## How do we fix it?

We install LFS support into the git client.
For consistency, as these docker images are already using the "latest-stable" release of the git core from its private package area (done in #113), we use the equivalent "latest-stable" version of git-lfs from [its private package area](https://github.com/git-lfs/git-lfs/blob/main/INSTALLING.md) too.

## What's the impact?

Git-lfs adds approximately 15 megabytes to the image, which is a 1.4% increase overall.
