### PR TITLE
Explicitly add libmagic

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -60,6 +60,7 @@ RUN noInstallRecommends="" && \
 		gzip \
 		jq \
 		libcurl4-openssl-dev \
+		libmagic-dev \
 		# popular DB lib - MariaDB
 		libmariadb-dev \
 		# allows MySQL users to use MariaDB lib

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -60,6 +60,7 @@ RUN noInstallRecommends="" && \
 		gzip \
 		jq \
 		libcurl4-openssl-dev \
+		libmagic-dev \
 		# popular DB lib - MariaDB
 		libmariadb-dev \
 		# allows MySQL users to use MariaDB lib

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -60,6 +60,7 @@ RUN noInstallRecommends="" && \
 		gzip \
 		jq \
 		libcurl4-openssl-dev \
+		libmagic-dev \
 		# popular DB lib - MariaDB
 		libmariadb-dev \
 		# allows MySQL users to use MariaDB lib

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -60,6 +60,7 @@ RUN noInstallRecommends="" && \
 		gzip \
 		jq \
 		libcurl4-openssl-dev \
+		libmagic-dev \
 		# popular DB lib - MariaDB
 		libmariadb-dev \
 		# allows MySQL users to use MariaDB lib


### PR DESCRIPTION
Two libmagic support packages were installed in the Focal based image, but not directly by us. So with Jammy and "no-install-recommends" they weren't getting installed. For some packages this is okay, but libmagic is very useful in Python and Ruby worlds, and I'm sure other languages. Explicitly installing now.