### PR TITLE
fix: Upgrade yq to fix vuln

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -128,7 +128,7 @@ RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	# Tests if docker-compose for v1 is transposed to v2
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.30.5/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 

--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -128,7 +128,7 @@ RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	# Tests if docker-compose for v1 is transposed to v2
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.30.5/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -128,7 +128,7 @@ RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	# Tests if docker-compose for v1 is transposed to v2
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.30.5/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -128,7 +128,7 @@ RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	# Tests if docker-compose for v1 is transposed to v2
 	docker-compose version
 
-RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.27.5/yq_linux_amd64.tar.gz" | \
+RUN curl -sSL "https://github.com/mikefarah/yq/releases/download/v4.30.5/yq_linux_amd64.tar.gz" | \
 	tar -xz -C /usr/local/bin && \
 	mv /usr/local/bin/yq{_linux_amd64,}
 


### PR DESCRIPTION
Upgrade yq to a version with a newer Golang compiler (4.29+) to fix CVE-2022-27664.