### PR TITLE
add lsof to base image

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -70,6 +70,7 @@ RUN noInstallRecommends="" && \
 		libpq-dev \
 		libssl-dev \
 		libsqlite3-dev \
+		lsof \
 		make \
 		# for ssh-enabled builds
 		nano \


### PR DESCRIPTION
`lsof` is useful when checking for dangling file handlers in system tests