### PR TITLE
feat: install envsubst

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -57,6 +57,7 @@ RUN noInstallRecommends="" && \
 		# already installed but here for consistency
 		curl \
 		file \
+		gettext-base \
 		gnupg \
 		gzip \
 		jq \


### PR DESCRIPTION
Installs a utility named `envsubst` and its dependencies. This tool is already available on all of CircleCI's VM images, but has not yet been added to docker images.

**Purpose:** This tool can take in a string and properly replace environment values within it. This functionality is critical for basic orb functionality. Orbs currently attempt to do this using `eval` but this of course has unintended consequences. Using envsubst in orbs will allow better parameter support for environment variables.

[Example](https://www.baeldung.com/linux/envsubst-command#examples-of-use):
```sh
Hello user $USER in $DESKTOP_SESSION. It's time to say $HELLO!
```

```sh
$ export HELLO="good morning"
$ envsubst < welcome.txt
Hello user joe in Lubuntu. It's time to say good morning!
```

**Tests:** I have run this locally within the `cimg/base:current` docker image for testing.

```
$ sudo apt update
$ sudo apt install gettext-base
$ envsubst -h

Usage: envsubst [OPTION] [SHELL-FORMAT]

Substitutes the values of environment variables.

Operation mode:
  -v, --variables             output the variables occurring in SHELL-FORMAT

Informative output:
  -h, --help                  display this help and exit
  -V, --version               output version information and exit
```

**Reference:**
 - https://www.thegeekdiary.com/envsubst-command-not-found/
 - https://packages.debian.org/stretch/gettext-base
 - https://www.gnu.org/software/gettext/