### PR TITLE
chore: Bump docker-compose

### DIFF
--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -57,6 +57,7 @@ RUN noInstallRecommends="" && \
 		# already installed but here for consistency
 		curl \
 		file \
+		gettext-base \
 		gnupg \
 		gzip \
 		jq \
@@ -116,7 +117,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VER 2.16.0
+ENV COMPOSE_VER 2.17.2
 ENV COMPOSE_SWITCH_VERSION 1.0.5
 RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	mkdir -p $dockerPluginDir && \

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -57,6 +57,7 @@ RUN noInstallRecommends="" && \
 		# already installed but here for consistency
 		curl \
 		file \
+		gettext-base \
 		gnupg \
 		gzip \
 		jq \
@@ -116,7 +117,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VER 2.16.0
+ENV COMPOSE_VER 2.17.2
 ENV COMPOSE_SWITCH_VERSION 1.0.5
 RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	mkdir -p $dockerPluginDir && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -117,7 +117,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VER 2.16.0
+ENV COMPOSE_VER 2.17.2
 ENV COMPOSE_SWITCH_VERSION 1.0.5
 RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	mkdir -p $dockerPluginDir && \


### PR DESCRIPTION
Update `docker-compose` version to patch security issues (from Trivy scanner):

```
usr/local/lib/docker/cli-plugins/docker-compose (gobinary)

┌──────────────────────────────────┬─────────────────────┬──────────┬───────────────────┬───────────────┬─────────────────────────────────────────────────────────────┐
│             Library              │    Vulnerability    │ Severity │ Installed Version │ Fixed Version │                            Title                            │
├──────────────────────────────────┼─────────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
│ github.com/containerd/containerd │ CVE-2023-25153      │ MEDIUM   │ v1.6.16           │ 1.6.18        │ containerd: OCI image importer memory exhaustion            │
│                                  │                     │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-25153                  │
│                                  ├─────────────────────┤          │                   │               ├─────────────────────────────────────────────────────────────┤
│                                  │ CVE-2023-25173      │          │                   │               │ containerd: Supplementary groups are not set up properly    │
│                                  │                     │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-25173                  │
├──────────────────────────────────┼─────────────────────┼──────────┼───────────────────┼───────────────┼─────────────────────────────────────────────────────────────┤
```

_Note:_ The `gettex-base` was present from template but missing from generated `Dockerfile`.



