### PR TITLE
chore: Bump docker-compose for security purpose

### DIFF
--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -120,7 +120,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VER 2.17.2
+ENV COMPOSE_VER 2.17.3
 ENV COMPOSE_SWITCH_VERSION 1.0.5
 RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	mkdir -p $dockerPluginDir && \

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -120,7 +120,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VER 2.17.2
+ENV COMPOSE_VER 2.17.3
 ENV COMPOSE_SWITCH_VERSION 1.0.5
 RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	mkdir -p $dockerPluginDir && \

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -120,7 +120,7 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VER 2.17.2
+ENV COMPOSE_VER 2.17.3
 ENV COMPOSE_SWITCH_VERSION 1.0.5
 RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	mkdir -p $dockerPluginDir && \


### PR DESCRIPTION
Update `docker-compose` version to patch security issues (from Trivy scanner):

```
usr/local/lib/docker/cli-plugins/docker-compose (gobinary)

├──────────────────────────────────┼─────────────────────┼──────────┼───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
│ github.com/opencontainers/runc   │ CVE-2023-27561      │ HIGH     │ v1.1.3            │ v1.1.5        │ runc: volume mount race condition (regression of         │
│                                  │                     │          │                   │               │ CVE-2019-19921)                                          │
│                                  │                     │          │                   │               │ https://avd.aquasec.com/nvd/cve-2023-27561               │
├──────────────────────────────────┼─────────────────────┤          ├───────────────────┼───────────────┼──────────────────────────────────────────────────────────┤
```

Docker-compose 2.17.3 [has updated runc to 1.1.5](https://github.com/docker/compose/releases/tag/v2.17.3) that [fixes multiple CVE](https://github.com/opencontainers/runc/releases/tag/v1.1.5).