### PR TITLE
chore: add python=python3 aliasing

### DIFF
--- a/20.04/Dockerfile
+++ b/20.04/Dockerfile
@@ -82,6 +82,7 @@ RUN noInstallRecommends="" && \
 		# compiling tool
 		pkg-config \
 		postgresql-client \
+		python-is-python3 \
 		shellcheck \
 		software-properties-common \
 		# already installed but here for consistency
@@ -99,6 +100,8 @@ RUN noInstallRecommends="" && \
 	curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && \
 	# Quick test of the git & git-lfs install
 	git version && git lfs version && \
+	# Smoke test for python aliasing
+	python --version && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work

--- a/22.04/Dockerfile
+++ b/22.04/Dockerfile
@@ -82,6 +82,7 @@ RUN noInstallRecommends="" && \
 		# compiling tool
 		pkg-config \
 		postgresql-client \
+		python-is-python3 \
 		shellcheck \
 		software-properties-common \
 		# already installed but here for consistency
@@ -99,6 +100,8 @@ RUN noInstallRecommends="" && \
 	curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && \
 	# Quick test of the git & git-lfs install
 	git version && git lfs version && \
+	# Smoke test for python aliasing
+	python --version && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work

--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -82,6 +82,7 @@ RUN noInstallRecommends="" && \
 		# compiling tool
 		pkg-config \
 		postgresql-client \
+		python-is-python3 \
 		shellcheck \
 		software-properties-common \
 		# already installed but here for consistency
@@ -99,6 +100,8 @@ RUN noInstallRecommends="" && \
 	curl -s https://packagecloud.io/install/repositories/github/git-lfs/script.deb.sh | bash && apt-get install -y git-lfs && \
 	# Quick test of the git & git-lfs install
 	git version && git lfs version && \
+	# Smoke test for python aliasing
+	python --version && \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker - needs the setup_remote_docker CircleCI step to work


### PR DESCRIPTION
Should close out https://github.com/CircleCI-Public/cimg-aws/issues/7

However, because at least one orb uses python 2, `aws-ecs-orb`, this will need to be addressed as well