### PR TITLE
add signing for monthly publishes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,5 +1,8 @@
 version: 2.1
 
+orbs:
+  aws-cli: circleci/aws-cli@4.1.0
+
 parameters:
   cron:
     type: boolean
@@ -13,6 +16,7 @@ workflows:
       - test:
           context: cimg-publishing
       - publish-monthly:
+          sign_arn: arn:aws:iam::483285841698:role/cpe-kms-sign
           requires:
             - test
           context: cimg-publishing
@@ -43,6 +47,7 @@ workflows:
               ignore: /.*/
           context: cimg-publishing
       - publish-monthly:
+          sign_arn: arn:aws:iam::483285841698:role/cpe-kms-sign
           requires:
             - test
           filters:
@@ -60,6 +65,59 @@ commands:
           command: |
             sudo apt-get update
             sudo apt-get install -y qemu-user-static binfmt-support
+  sign-images:
+    parameters:
+      sign_arn:
+        type: string
+      sign_session:
+        type: string
+        default: "sign-docker-images"
+      sign_profile_name:
+        type: string
+        default: "default"
+    steps:
+      - run:
+          name: Install Cosign
+          command: |
+            url="https://github.com/sigstore/cosign/releases/latest/download/cosign-linux"
+            [[ $(uname -m) == "x86_64" ]] && ARCH="amd64" || ARCH="arm64"
+
+            if ! cosign version &> /dev/null; then
+              curl -O -L "$url-$ARCH" && \
+              sudo mv cosign-linux-$ARCH /usr/local/bin/cosign && \
+              sudo chmod +x /usr/local/bin/cosign
+            fi
+      - aws-cli/setup:
+          region: ${AWS_DEFAULT_REGION}
+          role_arn: <<parameters.sign_arn>>
+          role_session_name: <<parameters.sign_session>>
+          profile_name: <<parameters.sign_profile_name>>
+      - run:
+          name: "Sign Images"
+          command: |
+            COSIGN_REPOSITORY=cimg/signatures
+            export COSIGN_REPOSITORY
+            
+            while IFS= read -r line; do
+              IFS=' ' read -ra slugs \<<< "$line"
+              parseNext=false
+
+              for slug in "${slugs[@]}"; do
+                if [ "$slug" == "-t" ]; then
+                  parseNext=true
+                elif [ "$parseNext" == true ]; then
+                  slug=${slug//\$\{VERSION\}/$(date +%Y.%m)}
+                  docker buildx imagetools inspect "$slug" --format "{{json .Manifest}}" > manifest.json
+                  digest=$(jq -r ".digest" "manifest.json")
+                  if [[ $slug =~ [0-9]+\.[0-9]+\- ]]; then
+                    cosign sign --yes --recursive --key "$KMS_KEY" "$slug@$digest"
+                    cosign verify --key "$KMS_KEY" "$slug"
+                  fi
+                  parseNext=false
+                fi
+              done
+            done < ./push-monthly-images.sh
+
 
 jobs:
   test:
@@ -77,7 +135,7 @@ jobs:
           name: "Publish Docker Hub Description (main branch only)"
           command: |
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
-             
+
               echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
 
               # Update the Docker Hub description
@@ -108,6 +166,15 @@ jobs:
             fi
 
   publish-monthly:
+    parameters:
+      sign_arn:
+        type: string
+      sign_session:
+        type: string
+        default: "sign-docker-images"
+      sign_profile_name:
+        type: string
+        default: "default"
     machine:
       image: ubuntu-2204:2022.07.1
     steps:
@@ -125,3 +192,7 @@ jobs:
               echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
               ./push-monthly-images.sh
             fi
+      - sign-images:
+          sign_arn: <<parameters.sign_arn>>
+          sign_session: <<parameters.sign_session>>
+          sign_profile_name: <<parameters.sign_profile_name>>


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.
- signs monthly releases for cimg-base

# Reasons
Please provide reasoning for these changes and how this PR achieves them.
- provides a chain of responsibility for the rest of our cimgs and allows our images to be verified as signed
- this would have been included with the cimg-orb, however, there are a bit of formatting issues along with the structure of generated dockerfiles that make this more of an edge case than it should be

If applicable, include a link to the related GitHub issue that this PR will close.


# Checklist

Please check through the following before opening your PR. Thank you!

- [N/A] I have made changes to the `Dockerfile.template` file only
- [x] I have not made any manual changes to automatically generated files
- [x] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [x] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
