### PR TITLE
Update to non-deprecated machine image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -73,7 +73,7 @@ commands:
 jobs:
   test:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:current
     steps:
       - checkout
       - setup-buildx-deps
@@ -84,7 +84,7 @@ jobs:
 
   publish-edge:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:current
     steps:
       - checkout
       - setup-buildx-deps
@@ -120,7 +120,7 @@ jobs:
 
   publish-monthly:
     machine:
-      image: ubuntu-2204:2022.07.1
+      image: ubuntu-2204:current
     steps:
       - checkout
       - setup-buildx-deps

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -74,6 +74,7 @@ jobs:
   test:
     machine:
       image: ubuntu-2204:current
+    resource_class: 2xlarge+
     steps:
       - checkout
       - setup-buildx-deps
@@ -85,6 +86,7 @@ jobs:
   publish-edge:
     machine:
       image: ubuntu-2204:current
+    resource_class: 2xlarge+
     steps:
       - checkout
       - setup-buildx-deps
@@ -121,6 +123,7 @@ jobs:
   publish-monthly:
     machine:
       image: ubuntu-2204:current
+    resource_class: 2xlarge+
     steps:
       - checkout
       - setup-buildx-deps


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
A brief description of the changes in this PR.

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
