### PR TITLE
Publish dockerhub description in publish job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -81,22 +81,6 @@ jobs:
           name: "Build Dockerfiles"
           command: |
             ./build-images.sh
-            echo 'export DOCKER_PASS=$DOCKER_TOKEN' >> $BASH_ENV
-      - run:
-          name: "Publish Docker Hub Description (main branch only)"
-          command: |
-            if [ "${CIRCLE_BRANCH}" == "main" ]; then
-
-              echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
-
-              # Update the Docker Hub description
-              SONAR_VER=0.15.0
-              SONAR_URL="https://github.com/felicianotech/sonar/releases/download/v${SONAR_VER}/sonar-v${SONAR_VER}-linux-amd64.tar.gz"
-              mkdir -p $HOME/bin
-              curl -sSL $SONAR_URL | tar -xz -C $HOME/bin sonar
-
-              sonar set description cimg/base ./README.md
-            fi
 
   publish-edge:
     machine:
@@ -114,6 +98,21 @@ jobs:
             if [ "${CIRCLE_BRANCH}" == "main" ]; then
               echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
               ./push-base-images.sh
+            fi
+      - run:
+          name: "Publish Docker Hub Description (main branch only)"
+          command: |
+            if [ "${CIRCLE_BRANCH}" == "main" ]; then
+
+              echo $DOCKER_TOKEN | docker login -u $DOCKER_USER --password-stdin
+
+              # Update the Docker Hub description
+              SONAR_VER=0.15.0
+              SONAR_URL="https://github.com/felicianotech/sonar/releases/download/v${SONAR_VER}/sonar-v${SONAR_VER}-linux-amd64.tar.gz"
+              mkdir -p $HOME/bin
+              curl -sSL $SONAR_URL | tar -xz -C $HOME/bin sonar
+
+              sonar set description cimg/base ./README.md
             fi
 
   publish-monthly:


### PR DESCRIPTION
For our official CircleCI Docker Convenience Image support policy, please see [CircleCI docs](https://circleci.com/docs/convenience-images-support-policy).

This policy outlines the release, update, and deprecation policy for CircleCI Docker Convenience Images.

---

# Description
The publishing of the dockerhub readme shouldn't happen in the test job. 

# Reasons
Please provide reasoning for these changes and how this PR achieves them.

If applicable, include a link to the related GitHub issue that this PR will close.

# Checklist

Please check through the following before opening your PR. Thank you!

- [ ] I have made changes to the `Dockerfile.template` file only
- [ ] I have not made any manual changes to automatically generated files
- [ ] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
