### PR TITLE
fix: use key=value in Dockerfile.template

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -117,8 +117,8 @@ RUN apt-get update && apt-get install -y \
 	rm -rf /var/lib/apt/lists/*
 
 # Install Docker Compose - see prerequisite above
-ENV COMPOSE_VER 2.27.1
-ENV COMPOSE_SWITCH_VERSION 1.0.5
+ENV COMPOSE_VER=2.27.1
+ENV COMPOSE_SWITCH_VERSION=1.0.5
 RUN dockerPluginDir=/usr/local/lib/docker/cli-plugins && \
 	mkdir -p $dockerPluginDir && \
 	curl -sSL "https://github.com/docker/compose/releases/download/v${COMPOSE_VER}/docker-compose-linux-$(uname -m)" -o $dockerPluginDir/docker-compose && \


### PR DESCRIPTION
# Description

Update [Dockerfile.template](https://github.com/CircleCI-Public/cimg-base/blob/main/Dockerfile.template) to use non-legacy `ENV key=value` syntax.

# Reasons

When building a Docker image locally with Docker Desktop `v4.47.0` (latest version), Docker shows warnings:

> - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 120)
> - LegacyKeyValueFormat: "ENV key=value" should be used instead of legacy "ENV key value" format (line 121)

See [LegacyKeyValueFormat](https://docs.docker.com/reference/build-checks/legacy-key-value-format/)

Docker Desktop [4.33.0](https://docs.docker.com/desktop/release-notes/#4330), released in July 2024, introduced new BuildKit checking:
> BuildKit now evaluates Dockerfile rules to inform you of potential issues.

# Checklist

Please check through the following before opening your PR. Thank you!

- [X] I have made changes to the `Dockerfile.template` file only
- [X] I have not made any manual changes to automatically generated files
- [X] My PR follows best practices as described in the [contributing guidelines](CONTRIBUTING)
- [ ] (Optional, but recommended) My commits are [signed](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
